### PR TITLE
Fixed special characters used in callbackUrl query parameters

### DIFF
--- a/packages/ui/react-ui/src/CrossMintPopupProvider.tsx
+++ b/packages/ui/react-ui/src/CrossMintPopupProvider.tsx
@@ -27,15 +27,15 @@ export const CrossMintPopupProvider: FC<PopupProviderProps> = ({ development, ch
         listingId?: string
     ) => {
         const pop = window.open(
-            `${development ? DEV_URL : PROD_URL}/signin?callbackUrl=${encodeURIComponent(
-                `${development ? DEV_URL : PROD_URL}/checkout/mint?clientId=${clientId}&closeOnSuccess=false&${
-                    collectionTitle ? `collectionTitle=${collectionTitle}` : ""
-                }${collectionDescription ? `&collectionDescription=${collectionDescription}` : ""}${
-                    collectionPhoto ? `&collectionPhoto=${collectionPhoto}` : ""
-                }${mintTo ? `&mintTo=${mintTo}` : ""}${emailTo ? `&emailTo=${emailTo}` : ""}${
-                    listingId ? `&listingId=${listingId}` : ""
-                }`
-            )}`,
+                `${development ? DEV_URL : PROD_URL}/signin?callbackUrl=${encodeURIComponent(
+                        `${development ? DEV_URL : PROD_URL}/checkout/mint?clientId=${encodeURIComponent(clientId)}&closeOnSuccess=false&${
+                                collectionTitle ? `collectionTitle=${encodeURIComponent(collectionTitle)}` : ""
+                                }${collectionDescription ? `&collectionDescription=${encodeURIComponent(collectionDescription)}` : ""}${
+                                collectionPhoto ? `&collectionPhoto=${encodeURIComponent(collectionPhoto)}` : ""
+                                }${mintTo ? `&mintTo=${encodeURIComponent(mintTo)}` : ""}${emailTo ? `&emailTo=${encodeURIComponent(emailTo)}` : ""}${
+                                listingId ? `&listingId=${encodeURIComponent(listingId)}` : ""
+                                }`
+                )}`,
             "popUpWindow",
             createPopupString()
         );


### PR DESCRIPTION
Issue: https://github.com/Paella-Labs/crossbit-main/issues/238

Long story short: It was crashing when the title or description for the collection had special characters such as “

The root cause is that we were only encoding the parameters inside the callbackUrl once. So when on the backend side we decoded the callbackUrl parameter, its own query parameters were absolutely decoded as well. They should instead still be encoded "once" so that when the customer is redirected to that callbackUrl they are properly handled.

So now we encode the callbackUrl parameter (once) but also its own parameters again (so "twice") so that they are decoded once first and then twice.