### PR TITLE
Stop making API requests with unset client ID

### DIFF
--- a/packages/ui/react-ui/src/CrossMintStatusProvider.tsx
+++ b/packages/ui/react-ui/src/CrossMintStatusProvider.tsx
@@ -19,6 +19,11 @@ export const CrossMintStatusProvider: FC<CrossMintStatusProviderProps> = ({
     );
 
     async function fetchClientIntegration() {
+        if (!clientId || clientId === "" || clientId === "<YOUR_CLIENT_ID>") {
+            console.warn("You must enter your own CrossMint client ID in <CrossMintProvider clientId=XXX>");
+            return;
+        }
+        
         const res = await fetch(`https://www.crossmint.io/api/crossmint/onboardingRequests/${clientId}/status`);
 
         if (res.status === 200) {


### PR DESCRIPTION
Addresses #14 

We're getting hammered with requests from folks integrating crossmint who haven't yet added their own client ID

This just checks for the most common cases where it's not yet set, and throws a warning instead of trying to call the API