### PR TITLE
react-ui - fix postbuild script

### DIFF
--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -28,7 +28,7 @@
     "scripts": {
         "clean": "shx rm -rf lib/*",
         "build": "yarn clean && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
-        "postbuild": "echo {\"type\":\"commonjs\"} | npx json > lib/cjs/package.json && echo {\"type\":\"module\"} | npx json > lib/esm/package.json"
+        "postbuild": "shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json && shx echo '{ \"type\": \"module\" }' > lib/esm/package.json"
     },
     "peerDependencies": {
         "react": "^17.0.2",


### PR DESCRIPTION
Hey guys!

It looks like the postbuild script was failing when trying to create the package.json in both `cjs` and `esm` folder, and was producing invalid json:

![Screenshot 2022-02-12 at 11 10 24](https://user-images.githubusercontent.com/20989060/153706974-1f7d1b61-3d4b-4f70-9bbe-d0f207a65d38.png)

![Screenshot 2022-02-12 at 11 13 30](https://user-images.githubusercontent.com/20989060/153707068-9a93da54-683f-4a0a-ba40-d3e37fbfbf02.png)

Now it should output the format correctly.

Thanks! 🙏 