### PR TITLE
Add launchpad id and mintConfig props

### DIFF
--- a/packages/ui/react-ui/__tests__/CrossmintStatusButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintStatusButton.spec.tsx
@@ -3,7 +3,6 @@ import { render, fireEvent, screen, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { CrossmintStatusButton } from "../src/CrossmintStatusButton";
-import { launchpadIds } from "../src/types";
 
 // TODO(#60): create a global service for this to work everywhere and to be able to customize resolved/rejected responses
 const fetchReturns = Promise.resolve({
@@ -17,7 +16,7 @@ global.open = jest.fn(() => openReturns);
 
 const defaultProps = {
     clientId: "a4e1bfcc-9884-11ec-b909-0242ac120002",
-    launchpadId: launchpadIds.holaplex,
+    platformId: "random-uuid",
     auctionId: "123456",
 };
 
@@ -33,12 +32,12 @@ describe("CrossmintPayButton", () => {
             fireEvent.click(screen.getByText("Click here to setup CrossMint"));
         });
         expect(global.open).toHaveBeenCalledWith(
-            `https://www.crossmint.io/developers/onboarding?clientId=${defaultProps.clientId}&launchpadId=${defaultProps.launchpadId}&auctionId=${defaultProps.auctionId}`,
+            `https://www.crossmint.io/developers/onboarding?clientId=${defaultProps.clientId}&platformId=${defaultProps.platformId}&auctionId=${defaultProps.auctionId}`,
             "_blank"
         );
     });
 
-    test("should not send launchpadId and auctionId if not provided", async () => {
+    test("should not send platformId and auctionId if not provided", async () => {
         render(<CrossmintStatusButton clientId={defaultProps.clientId} />);
 
         await act(async () => {

--- a/packages/ui/react-ui/__tests__/CrossmintStatusButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintStatusButton.spec.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, fireEvent, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { CrossmintStatusButton } from "../src/CrossmintStatusButton";
+import { launchpadIds } from "../src/types";
+
+// TODO(#60): create a global service for this to work everywhere and to be able to customize resolved/rejected responses
+const fetchReturns = Promise.resolve({
+    json: () => Promise.resolve({}),
+}) as any;
+global.fetch = jest.fn(() => fetchReturns);
+
+// TODO(#61): make this automatically mocked in every test suite
+const openReturns = {} as Window;
+global.open = jest.fn(() => openReturns);
+
+const defaultProps = {
+    clientId: "a4e1bfcc-9884-11ec-b909-0242ac120002",
+    launchpadId: launchpadIds.holaplex,
+    auctionId: "123456",
+};
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("CrossmintPayButton", () => {
+    test("should open onboarding page on click", async () => {
+        render(<CrossmintStatusButton {...defaultProps} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("Click here to setup CrossMint"));
+        });
+        expect(global.open).toHaveBeenCalledWith(
+            `https://www.crossmint.io/developers/onboarding?clientId=${defaultProps.clientId}&launchpadId=${defaultProps.launchpadId}&auctionId=${defaultProps.auctionId}`,
+            "_blank"
+        );
+    });
+
+    test("should not send launchpadId and auctionId if not provided", async () => {
+        render(<CrossmintStatusButton clientId={defaultProps.clientId} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("Click here to setup CrossMint"));
+        });
+        expect(global.open).toHaveBeenCalledWith(
+            `https://www.crossmint.io/developers/onboarding?clientId=${defaultProps.clientId}`,
+            "_blank"
+        );
+    });
+});

--- a/packages/ui/react-ui/src/CrossmintStatusButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintStatusButton.tsx
@@ -1,10 +1,16 @@
 import React, { FC, MouseEventHandler, useMemo, useCallback } from "react";
 import useCrossmintStatus, { OnboardingRequestStatusResponse } from "./hooks/useCrossmintStatus";
 import { useStyles, formatProps } from "./styles";
-import { baseUrls, BaseButtonProps } from "./types";
+import { baseUrls, CrossmintStatusButtonProps } from "./types";
 import { isClientSide } from "./utils";
 
-export const CrossmintStatusButton: FC<BaseButtonProps> = ({
+type OnboardingQueryParams = {
+    clientId: string;
+    launchpadId?: string;
+    auctionId?: string;
+};
+
+export const CrossmintStatusButton: FC<CrossmintStatusButtonProps> = ({
     className,
     disabled,
     onClick,
@@ -14,22 +20,33 @@ export const CrossmintStatusButton: FC<BaseButtonProps> = ({
     clientId,
     auctionId,
     development = false,
+    launchpadId,
     ...props
 }) => {
     const status = useCrossmintStatus({ clientId, development });
+
+    const formatOnboardingQueryParams = () => {
+        const onboardingQueryParams: OnboardingQueryParams = {
+            clientId: clientId,
+        };
+
+        if (launchpadId) onboardingQueryParams.launchpadId = launchpadId;
+        if (auctionId) onboardingQueryParams.auctionId = auctionId;
+
+        return new URLSearchParams(onboardingQueryParams).toString();
+    };
+
+    const goToOnboarding = () => {
+        const baseUrl = development ? baseUrls.dev : baseUrls.prod;
+        window.open(`${baseUrl}/developers/onboarding?${formatOnboardingQueryParams()}`, "_blank");
+    };
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
         (event) => {
             if (onClick) onClick(event);
 
             if (status === OnboardingRequestStatusResponse.WAITING_SUBMISSION) {
-                const baseUrl = development ? baseUrls.dev : baseUrls.prod;
-                window.open(
-                    `${baseUrl}/developers/onboarding${clientId ? `?clientId=${clientId}` : ""}${
-                        auctionId ? `&auctionId=${auctionId}` : ""
-                    }`,
-                    "_blank"
-                );
+                goToOnboarding();
                 return;
             }
         },

--- a/packages/ui/react-ui/src/CrossmintStatusButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintStatusButton.tsx
@@ -6,7 +6,7 @@ import { isClientSide } from "./utils";
 
 type OnboardingQueryParams = {
     clientId: string;
-    launchpadId?: string;
+    platformId?: string;
     auctionId?: string;
 };
 
@@ -20,7 +20,7 @@ export const CrossmintStatusButton: FC<CrossmintStatusButtonProps> = ({
     clientId,
     auctionId,
     development = false,
-    launchpadId,
+    platformId,
     ...props
 }) => {
     const status = useCrossmintStatus({ clientId, development });
@@ -30,7 +30,7 @@ export const CrossmintStatusButton: FC<CrossmintStatusButtonProps> = ({
             clientId: clientId,
         };
 
-        if (launchpadId) onboardingQueryParams.launchpadId = launchpadId;
+        if (platformId) onboardingQueryParams.platformId = platformId;
         if (auctionId) onboardingQueryParams.auctionId = auctionId;
 
         return new URLSearchParams(onboardingQueryParams).toString();

--- a/packages/ui/react-ui/src/types.ts
+++ b/packages/ui/react-ui/src/types.ts
@@ -25,11 +25,6 @@ export enum mintingContractTypes {
     ERC_721 = "erc-721",
 }
 
-export enum launchpadIds {
-    // TODO Replace with the real one
-    holaplex = "12345",
-}
-
 export interface PayButtonConfig {
     type: string;
 
@@ -65,6 +60,6 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
 }
 
 export interface CrossmintStatusButtonProps extends BaseButtonProps {
-    launchpadId?: launchpadIds;
+    platformId?: string;
     mintConfig?: StatusButtonConfig;
 }

--- a/packages/ui/react-ui/src/types.ts
+++ b/packages/ui/react-ui/src/types.ts
@@ -25,9 +25,18 @@ export enum mintingContractTypes {
     ERC_721 = "erc-721",
 }
 
+export enum launchpadIds {
+    // TODO Replace with the real one
+    holaplex = "12345",
+}
+
 export interface PayButtonConfig {
     type: string;
 
+    [propName: string]: any;
+}
+
+export interface StatusButtonConfig {
     [propName: string]: any;
 }
 
@@ -53,4 +62,9 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
     showOverlay?: boolean;
     hideMintOnInactiveClient?: boolean;
     mintConfig?: PayButtonConfig;
+}
+
+export interface CrossmintStatusButtonProps extends BaseButtonProps {
+    launchpadId?: launchpadIds;
+    mintConfig?: StatusButtonConfig;
 }


### PR DESCRIPTION
It adds a few extra props on the Status button:
- `launchpadId` to keep track of which we are coming from. It would be added on the onboarding endpoint as a query param
- `configMint` object to store specifics for each implementarion/chain/launchpad. This follows the same philosophy that the same field in the Pay button (no client side validation for now)

Also:
- Little refactor on the way we build the onboarding url
- Unit tests to ensure everything keeps working 😅 

Thanks!