### PR TITLE
Enforce that the button always opens a popup

### DIFF
--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -20,9 +20,9 @@ type MintQueryParams = {
 const overlayId = "__crossmint-overlay__";
 
 function createPopupString() {
-    return `height=750,width=400,left=${window.innerWidth / 2 - 200},top=${
-        window.innerHeight / 2 - 375
-    },resizable=yes,scrollbars=yes,toolbar=yes,menubar=true,location=no,directories=no, status=yes`;
+    const left = window.innerWidth / 2 - 200;
+    const top = window.innerHeight / 2 - 375;
+    return `popup=true,height=750,width=400,left=${left},top=${top},resizable=yes,scrollbars=yes,toolbar=yes,menubar=true,location=no,directories=no, status=yes`;
 }
 
 const addLoadingOverlay = (): void => {
@@ -111,7 +111,7 @@ export function crossmintModalService({
         };
         const callbackUrl = encodeURIComponent(`${urlOrigin}/checkout/mint?${getMintQueryParams()}`);
         const url = `${urlOrigin}/signin?callbackUrl=${callbackUrl}`;
-
+        console.log(createPopupString());
         const pop = window.open(url, "popUpWindow", createPopupString());
         if (pop) {
             registerListeners(pop);


### PR DESCRIPTION
For some reason, (maybe chrome update?) our button was no longer opening a popup but a tab. 


https://user-images.githubusercontent.com/20989060/166885399-c22423ba-fe11-49f1-8170-ef7f07a33877.mov


Now with this change it does. Tested in Chrome and Firefox.