### PR TITLE
Add parts to Vanilla UI pay component

### DIFF
--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -191,9 +191,10 @@ export class CrossmintPayButton extends LitElement {
                 .disabled=${this.disabled}
                 @click=${_handleClick}
                 tabindex=${this.tabIndex}
+                part="button"
             >
                 <img src="https://www.crossmint.io/assets/crossmint/logo.png" alt="Crossmint logo" />
-                <p>${content}</p>
+                <p part="contentParagraph">${content}</p>
             </button>
         `;
     }


### PR DESCRIPTION
Adding parts for outside styling for web component. See `::part()` [specification](https://developer.mozilla.org/en-US/docs/Web/CSS/::part).