### PR TITLE
Replacing p for span in vanilla ui buttons

### DIFF
--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -194,7 +194,7 @@ export class CrossmintPayButton extends LitElement {
                 part="button"
             >
                 <img src="https://www.crossmint.io/assets/crossmint/logo.png" alt="Crossmint logo" />
-                <p part="contentParagraph">${content}</p>
+                <span part="contentParagraph">${content}</span>
             </button>
         `;
     }

--- a/packages/ui/vanilla-ui/src/CrossmintStatusButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintStatusButton.ts
@@ -109,7 +109,7 @@ export class CrossmintStatusButton extends LitElement {
                 tabindex=${this.tabIndex}
             >
                 <img src="https://www.crossmint.io/assets/crossmint/logo.png" alt="Crossmint logo" />
-                <p>${content}</p>
+                <span>${content}</span>
             </button>
         `;
     }


### PR DESCRIPTION
Its a better practice to have spans inside the buttons. 