### PR TITLE
Remove light theme

### DIFF
--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@crossmint/client-sdk-base": "^0.1.3-alpha.1",
-        "react-jss": "10.9.1-alpha.1",
+        "react-jss": "10.9.0",
         "uuid": "^8.3.2"
     },
     "peerDependencies": {

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -10,7 +10,7 @@ import {
     onboardingRequestStatusResponse,
 } from "@crossmint/client-sdk-base";
 
-import { formatProps, useStyles } from "./styles";
+import { useStyles } from "./styles";
 import { CrossmintPayButtonReactProps } from "./types";
 import useEnvironment from "./useEnvironment";
 import { LIB_VERSION } from "./version";
@@ -103,7 +103,8 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
             );
         });
 
-    const classes = useStyles(formatProps(theme));
+    // const classes = useStyles(formatProps(theme));
+    const classes = useStyles();
 
     const content = useMemo(() => {
         return (

--- a/packages/ui/react-ui/src/CrossmintStatusButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintStatusButton.tsx
@@ -8,7 +8,7 @@ import {
     onboardingRequestStatusResponse,
 } from "@crossmint/client-sdk-base";
 
-import { formatProps, useStyles } from "./styles";
+import { useStyles } from "./styles";
 import { CrossmintStatusButtonReactProps } from "./types";
 import useEnvironment from "./useEnvironment";
 import { LIB_VERSION } from "./version";
@@ -54,7 +54,8 @@ export const CrossmintStatusButton: FC<CrossmintStatusButtonReactProps> = ({
         return () => clearInterval(interval);
     }, []);
 
-    const classes = useStyles(formatProps(theme));
+    // const classes = useStyles(formatProps(theme));
+    const classes = useStyles();
 
     const content = useMemo(() => {
         return <span className={classes.crossmintParagraph}>{getButtonText(status)}</span>;

--- a/packages/ui/react-ui/src/styles/index.ts
+++ b/packages/ui/react-ui/src/styles/index.ts
@@ -2,16 +2,16 @@ import { createUseStyles } from "react-jss";
 
 const DARK_BG = "#1e1e1e";
 
-interface CustomStylingProps {
+/* interface CustomStylingProps {
     buttonBgColor?: string;
     paragraphColor?: string;
-}
+} */
 
-const themeIsLight = (theme: string) => theme === "light";
+/* const themeIsLight = (theme: string) => theme === "light";
 export const formatProps = (theme: string): CustomStylingProps => ({
     buttonBgColor: themeIsLight(theme) ? "white" : DARK_BG,
     paragraphColor: themeIsLight(theme) ? "black" : "white",
-});
+}); */
 
 export const useStyles = createUseStyles({
     "@global": {
@@ -31,7 +31,8 @@ export const useStyles = createUseStyles({
         border: "none",
         "box-shadow": "0px 8px 15px rgba(0, 0, 0, 0.1)",
         "justify-content": "center",
-        background: ({ buttonBgColor }: CustomStylingProps) => buttonBgColor,
+        // background: ({ buttonBgColor }: CustomStylingProps) => buttonBgColor,
+        background: DARK_BG,
 
         "&:hover:enabled": {
             opacity: "0.6",
@@ -44,7 +45,8 @@ export const useStyles = createUseStyles({
         "margin-right": "0.875rem",
     },
     crossmintParagraph: {
-        color: ({ paragraphColor }: CustomStylingProps) => paragraphColor,
+        // color: ({ paragraphColor }: CustomStylingProps) => paragraphColor,
+        color: "white",
         margin: "0",
     },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5482,14 +5482,14 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
-css-jss@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/css-jss/-/css-jss-10.9.1-alpha.1.tgz#a6758d26a2e604b72e7ac672825912b48d5f818e"
-  integrity sha512-l2HpsxGAJWB5wvCp573Tl2RK6kHnO29U1AEcY0DCgryXIbQvRYliJAJPU0WzHE2JHozCjMZ+2QWU6UKkCawEDA==
+css-jss@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/css-jss/-/css-jss-10.9.0.tgz#1595c67bacf651100984a05763c1170d1bfa7127"
+  integrity sha512-CpYclti5ZQ18PfAeXaHQ2bEw4DEUfjC0lTS9sQcUlTRF8hC/Va0h3DIowlRm6AH/Ka/O/+tp41Q5zn9MJQoRsA==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
-    jss-preset-default "10.9.1-alpha.1"
+    jss "10.9.0"
+    jss-preset-default "10.9.0"
 
 css-loader@4.3.0:
   version "4.3.0"
@@ -9973,134 +9973,134 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
-jss-plugin-camel-case@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.9.1-alpha.1.tgz#cc6acf2e8c7a427053d4ad80d0b4c4861281b37a"
-  integrity sha512-FMfTgTm0VJZhhJAob9gUqOvWqbf4Ec0WZ/tGtiLbfgyJVFQKse9IwPWwTlE0wJ7aQQ/vODZoQ/GnI2B5h8PlXQ==
+jss-plugin-camel-case@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.9.0.tgz#4921b568b38d893f39736ee8c4c5f1c64670aaf7"
+  integrity sha512-UH6uPpnDk413/r/2Olmw4+y54yEF2lRIV8XIZyuYpgPYTITLlPOsq6XB9qeqv+75SQSg3KLocq5jUBXW8qWWww==
   dependencies:
     "@babel/runtime" "^7.3.1"
     hyphenate-style-name "^1.0.3"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
 
-jss-plugin-compose@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-compose/-/jss-plugin-compose-10.9.1-alpha.1.tgz#10251a0d837812554e2838d90d8160998b9a5bbc"
-  integrity sha512-hpiFoiCIqi8MWSMn/6/wID07K740AzfW1OJC58rXdh8AdzXLhgjoBTWakW+M4G4QyhAt+XkmTptzuKcacKg4og==
+jss-plugin-compose@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-compose/-/jss-plugin-compose-10.9.0.tgz#4954583227db9b49bd2e29cd055dcc65b12cb19d"
+  integrity sha512-Q/0FEZhDwGUpf3/b7+PspmMi6MVSlN3YlTDmvrft7I6N346jUpd8MYkYP/6qM1ZMuVj4v8ky/XYqr1v2ganLLg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
     tiny-warning "^1.0.2"
 
-jss-plugin-default-unit@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.9.1-alpha.1.tgz#1f7b6477ea44d7155d88786fa31d812f42eb44f3"
-  integrity sha512-TunbXTuChDX75DKl4g8F12S+qNG4bnAIVzctYOGW3BG8bAGtPTN3nmcUvlb9EuYNxaW763y/yqxLuyxTRmOJZg==
+jss-plugin-default-unit@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.9.0.tgz#bb23a48f075bc0ce852b4b4d3f7582bc002df991"
+  integrity sha512-7Ju4Q9wJ/MZPsxfu4T84mzdn7pLHWeqoGd/D8O3eDNNJ93Xc8PxnLmV8s8ZPNRYkLdxZqKtm1nPQ0BM4JRlq2w==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
 
-jss-plugin-expand@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-expand/-/jss-plugin-expand-10.9.1-alpha.1.tgz#1f44eb798545c8b3652f364157aedca9e80c2cf4"
-  integrity sha512-7ko+lyXk2jGBHU+cznU5uim/yyYt8fdbTjN7Qv4ECB0M/zWZP741n4oWeSVUYSTIh0NPL8QGKI9Z8Q85LQJVJQ==
+jss-plugin-expand@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-expand/-/jss-plugin-expand-10.9.0.tgz#96c902f5759fe189184f8418997659d61e927ffe"
+  integrity sha512-QfZ9jld0HpF1OiYU7cGWQ4q+f6+Wu93mV4X+cA1iVRssiUbSbygwdfZkUwX23UOhS1WWRJeQlLK1aJC94K8/0A==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
 
-jss-plugin-extend@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-extend/-/jss-plugin-extend-10.9.1-alpha.1.tgz#69b17c32f747a342b42f5317b80138ed1107f437"
-  integrity sha512-ulQrGN1b8cZJLzotwvtyJLAm/YBxWNZAW3QOWGfhwaEML1IhMYahk7qsBSP4oKWWQtb6AXMJaezyk1Ktj1xwPg==
+jss-plugin-extend@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-extend/-/jss-plugin-extend-10.9.0.tgz#b1163ceb25d908888b326e5b5fa780aaaed4884d"
+  integrity sha512-xvmosUh3RsKVsm9L14ml6PL3i0Ejj5gB6eo/jTMkGW1kIy42gNXV1EthR8cD5xiowWstnvugQ3JF0pI5+QkPMg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
     tiny-warning "^1.0.2"
 
-jss-plugin-global@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.9.1-alpha.1.tgz#787895cc0d09a80c16011d22a022236e3fe48a6d"
-  integrity sha512-SV++XojF1uRISOsZwm7BlRqiX6ljczSa0NptZvqhuk1nn+/tllgUfd+Er2s9rLm0Ypr6Ipf2rbTQY1DwYS8KEg==
+jss-plugin-global@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.9.0.tgz#fc07a0086ac97aca174e37edb480b69277f3931f"
+  integrity sha512-4G8PHNJ0x6nwAFsEzcuVDiBlyMsj2y3VjmFAx/uHk/R/gzJV+yRHICjT4MKGGu1cJq2hfowFWCyrr/Gg37FbgQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
 
-jss-plugin-nested@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.9.1-alpha.1.tgz#30b4c14b3dfe999d9ed6dcc964ec0548e3e7e9a4"
-  integrity sha512-1W8mAMRCQeOnIUzx5QJN/Z2V93Jp2Lx7fwlYemTwRewcf4K2jCJBUWn2QgEEt0/DUglXYFqVM+R09PrVivlNDA==
+jss-plugin-nested@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.9.0.tgz#cc1c7d63ad542c3ccc6e2c66c8328c6b6b00f4b3"
+  integrity sha512-2UJnDrfCZpMYcpPYR16oZB7VAC6b/1QLsRiAutOt7wJaaqwCBvNsosLEu/fUyKNQNGdvg2PPJFDO5AX7dwxtoA==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
     tiny-warning "^1.0.2"
 
-jss-plugin-props-sort@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.9.1-alpha.1.tgz#325c24e6896df05ed22a5907644f568e0c2528d2"
-  integrity sha512-0o7cjO68+GQk1WiFxx/q8nsjTSbgwVcElLzfTTdr+LmPmbjzr8wA92CDl0xN0ajcL8WK40uwqLqGywrfQdFYRw==
+jss-plugin-props-sort@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.9.0.tgz#30e9567ef9479043feb6e5e59db09b4de687c47d"
+  integrity sha512-7A76HI8bzwqrsMOJTWKx/uD5v+U8piLnp5bvru7g/3ZEQOu1+PjHvv7bFdNO3DwNPC9oM0a//KwIJsIcDCjDzw==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
 
-jss-plugin-rule-value-function@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.9.1-alpha.1.tgz#189527d107bf7916132e35bbebd7672a87371e6c"
-  integrity sha512-dm9K77JCIn5Aa10u6L8CS4Gh65n8/qX1Hdsm5l9F+P/4MVmYeFYoqVy/mFLNN7Mfw1AXtV40qUJnHXGm4Jvz7w==
+jss-plugin-rule-value-function@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.9.0.tgz#379fd2732c0746fe45168011fe25544c1a295d67"
+  integrity sha512-IHJv6YrEf8pRzkY207cPmdbBstBaE+z8pazhPShfz0tZSDtRdQua5jjg6NMz3IbTasVx9FdnmptxPqSWL5tyJg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
     tiny-warning "^1.0.2"
 
-jss-plugin-rule-value-observable@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-observable/-/jss-plugin-rule-value-observable-10.9.1-alpha.1.tgz#9ca24525e0be0b28694b505766824515e0858c2a"
-  integrity sha512-sHEKk4ZOLDDa6GqNryAfnIYuFx5qh6tfGw8puBcmc8hvMPKAFQo0XgYt8MRcQmdA47zRs/qR30gLjDWA2iIpGQ==
+jss-plugin-rule-value-observable@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-observable/-/jss-plugin-rule-value-observable-10.9.0.tgz#fc48b70f6915a913618fdadb44dedce23982b32d"
+  integrity sha512-/MWVPJVEn41+ofzQdsvH1GR4wusDqFqNnchh/98HVc580MxPy4NVkmUa2SAEpbHhnJ93sCoETZccW3HJKuvH4A==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
     symbol-observable "^1.2.0"
 
-jss-plugin-template@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-template/-/jss-plugin-template-10.9.1-alpha.1.tgz#cd8980398a0c11ddcc7cc36a4464bad5105735d8"
-  integrity sha512-sduBg0j4nkfN4kxFGFFwCa6x/BvBondWtMgX2KJBCjV69LQChamhyVp5+LXIm1wNa6Uevfx7A0Yf+NTRLQMd5A==
+jss-plugin-template@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-template/-/jss-plugin-template-10.9.0.tgz#27547e093e04b9dc9e900f35146e874bb196f575"
+  integrity sha512-lxThUvdt0drCi7xhuJWxADWTgLLy1IWCeFO5k+dtba900xJsNg0IGZplpP9w9UpaJsYS3WUwWMXw8Sxn1dobfQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
     tiny-warning "^1.0.2"
 
-jss-plugin-vendor-prefixer@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.9.1-alpha.1.tgz#41c42ea6f2fd705a466dfc47ea8a194d5c05a519"
-  integrity sha512-SeEHBH5Yp8TqXQZ26r8L35sm5gZfQyJYDrgHsFr1sQ8sx85YOh897mEAvRnvznBf2XXXEIqSRACFfbUwZfWaxA==
+jss-plugin-vendor-prefixer@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.9.0.tgz#aa9df98abfb3f75f7ed59a3ec50a5452461a206a"
+  integrity sha512-MbvsaXP7iiVdYVSEoi+blrW+AYnTDvHTW6I6zqi7JcwXdc6I9Kbm234nEblayhF38EftoenbM+5218pidmC5gA==
   dependencies:
     "@babel/runtime" "^7.3.1"
     css-vendor "^2.0.8"
-    jss "10.9.1-alpha.1"
+    jss "10.9.0"
 
-jss-preset-default@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-10.9.1-alpha.1.tgz#7ac6bbee48480d18f7467ff8b44ed2a2c022e783"
-  integrity sha512-u1w/gnKZb6eLEAfWYCZyM6LD7bv/b7epzfr7nuix+qFNVbuBaruVxUmtmMAKFxPGFi/eHG4jpN6A1/oNe16LjQ==
+jss-preset-default@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-10.9.0.tgz#20919ee04e543b3502086001c4179ab15c012153"
+  integrity sha512-Zdsj+R+UTn7OOJ1TFQi+l8PfEL7APSAM6vRPaU8mJywT8OrMjgslMKckFLrgq1k+qk1hJR1ePAMesvZ5aAXGOQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.9.1-alpha.1"
-    jss-plugin-camel-case "10.9.1-alpha.1"
-    jss-plugin-compose "10.9.1-alpha.1"
-    jss-plugin-default-unit "10.9.1-alpha.1"
-    jss-plugin-expand "10.9.1-alpha.1"
-    jss-plugin-extend "10.9.1-alpha.1"
-    jss-plugin-global "10.9.1-alpha.1"
-    jss-plugin-nested "10.9.1-alpha.1"
-    jss-plugin-props-sort "10.9.1-alpha.1"
-    jss-plugin-rule-value-function "10.9.1-alpha.1"
-    jss-plugin-rule-value-observable "10.9.1-alpha.1"
-    jss-plugin-template "10.9.1-alpha.1"
-    jss-plugin-vendor-prefixer "10.9.1-alpha.1"
+    jss "10.9.0"
+    jss-plugin-camel-case "10.9.0"
+    jss-plugin-compose "10.9.0"
+    jss-plugin-default-unit "10.9.0"
+    jss-plugin-expand "10.9.0"
+    jss-plugin-extend "10.9.0"
+    jss-plugin-global "10.9.0"
+    jss-plugin-nested "10.9.0"
+    jss-plugin-props-sort "10.9.0"
+    jss-plugin-rule-value-function "10.9.0"
+    jss-plugin-rule-value-observable "10.9.0"
+    jss-plugin-template "10.9.0"
+    jss-plugin-vendor-prefixer "10.9.0"
 
-jss@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-10.9.1-alpha.1.tgz#32cad51ad075445874517aeec7b6cdfa30b54c90"
-  integrity sha512-qoOVgZ8B3R/7MHxtku/CwUJ0+f0KYeuGzOccZ7KWsiC65fyFw50+RZw7JX0JoZfq/cZL+NP0+4tuUypmoNTFrQ==
+jss@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.9.0.tgz#7583ee2cdc904a83c872ba695d1baab4b59c141b"
+  integrity sha512-YpzpreB6kUunQBbrlArlsMpXYyndt9JATbt95tajx0t4MTJJcCJdd4hdNpHmOIDiUJrF/oX5wtVFrS3uofWfGw==
   dependencies:
     "@babel/runtime" "^7.3.1"
     csstype "^3.0.2"
@@ -13159,18 +13159,18 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-jss@10.9.1-alpha.1:
-  version "10.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-10.9.1-alpha.1.tgz#c507db500113977613a9565d931a1c31ac7d40fa"
-  integrity sha512-Ti+hvjN6/LJDMVKuhzmVpy8/CHT25lnoksE/o8bobckJMkCRV/Lqlv6BcaLM+bMp8C7FjuKVUxqzwdY6ANDjmw==
+react-jss@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-10.9.0.tgz#102332a109d98510f0f812dd090d02f6045b5229"
+  integrity sha512-xKXTEejrSkzINF+dutFtLllIfYSN6tOA1XmnpiZGjsWZqy7Hum6fjjgAE2TbBmV9h2CW62ekmGj/Mx27ZuMjuw==
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@emotion/is-prop-valid" "^0.7.3"
-    css-jss "10.9.1-alpha.1"
+    css-jss "10.9.0"
     hoist-non-react-statics "^3.2.0"
     is-in-browser "^1.1.3"
-    jss "10.9.1-alpha.1"
-    jss-preset-default "10.9.1-alpha.1"
+    jss "10.9.0"
+    jss-preset-default "10.9.0"
     prop-types "^15.6.0"
     shallow-equal "^1.2.0"
     theming "^3.3.0"


### PR DESCRIPTION
So we have a situation at the moment where our latest release is not correctly working on some React 17 environments. 

The reason for this is beacuse incompatibilities with the newest alpha version from `react-jss`. I have opened an issue here: https://github.com/cssinjs/jss/issues/1618

Now the reason why I had to update to the new alpha version is because the latest stable version was having trouble with dynamic styles in React 18.

So... in order to fix all of that, and as an emergency measure, I have disabled the theming in the button, that was the only place where we were using dynamic styles with `react-jss`.

This is an emergency measure until I hear back from the `react-jss` team.

Users that want to use `theme="light"` with this version will need to do it manually on their end. They can follow our styling guide from the docs. I can also assist with that if needed.