### PR TITLE
Add dismiss overlay on click

### DIFF
--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -66,6 +66,7 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
     emailTo?: string;
     listingId?: string;
     showOverlay?: boolean;
+    dismissOverlayOnClick?: boolean;
     hideMintOnInactiveClient?: boolean;
     mintConfig?: PayButtonConfig;
     whPassThroughArgs?: any;

--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -37,7 +37,7 @@ function createPopupString() {
     return `${popupStringBase}height=750,width=400,left=${left},top=${top},resizable=yes,scrollbars=yes,toolbar=yes,menubar=true,location=no,directories=no, status=yes`;
 }
 
-const addLoadingOverlay = (): void => {
+const addLoadingOverlay = (dissmissableOverlayOnClick?: boolean): void => {
     const overlayEl = document.createElement("div");
     overlayEl.setAttribute("id", overlayId);
     const overlayStyles = {
@@ -51,6 +51,12 @@ const addLoadingOverlay = (): void => {
     };
     Object.assign(overlayEl.style, overlayStyles);
     document.body.appendChild(overlayEl);
+
+    if (dissmissableOverlayOnClick) {
+        overlayEl.addEventListener("click", () => {
+            removeLoadingOverlay();
+        });
+    }
 };
 
 const removeLoadingOverlay = (): void => {
@@ -62,6 +68,7 @@ interface CrossmintModalServiceParams {
     clientId: string;
     libVersion: string;
     showOverlay: boolean;
+    dismissOverlayOnClick?: boolean;
     setConnecting: (connecting: boolean) => void;
     environment?: string;
     clientName: clientNames;
@@ -86,6 +93,7 @@ export function crossmintModalService({
     clientId,
     libVersion,
     showOverlay,
+    dismissOverlayOnClick,
     setConnecting,
     environment,
     clientName,
@@ -131,7 +139,7 @@ export function crossmintModalService({
         if (pop) {
             registerListeners(pop);
             if (showOverlay) {
-                addLoadingOverlay();
+                addLoadingOverlay(dismissOverlayOnClick);
             }
             return;
         }

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -41,6 +41,7 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
     environment,
     paymentMethod,
     preferredSigninMethod,
+    dismissOverlayOnClick,
     ...props
 }) => {
     const [connecting, setConnecting] = useState(false);
@@ -60,6 +61,7 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
     const { connect } = crossmintModalService({
         clientId,
         showOverlay,
+        dismissOverlayOnClick,
         setConnecting,
         libVersion: LIB_VERSION,
         environment,

--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -38,6 +38,7 @@ const propertyDefaults: CrossmintPayButtonLitProps = {
     whPassThroughArgs: undefined,
     paymentMethod: undefined,
     preferredSigninMethod: undefined,
+    dismissOverlayOnClick: false,
 };
 
 @customElement("crossmint-pay-button")
@@ -97,6 +98,9 @@ export class CrossmintPayButton extends LitElement {
 
     @property({ type: String })
     preferredSigninMethod = propertyDefaults.preferredSigninMethod;
+
+    @property({ type: Boolean })
+    dismissOverlayOnClick = propertyDefaults.dismissOverlayOnClick;
 
     static styles = buttonStyles;
 
@@ -162,6 +166,7 @@ export class CrossmintPayButton extends LitElement {
             environment: this.environment,
             clientId: this.clientId,
             showOverlay: this.showOverlay || true,
+            dismissOverlayOnClick: this.dismissOverlayOnClick,
             setConnecting: this.setConnecting,
             libVersion: LIB_VERSION,
             clientName: clientNames.vanillaUi,


### PR DESCRIPTION
Petition from magic eden: users should be able to tap / click on overlay and keep browsing. Adding new prop `dismissOverlayOnClick` to achieve that.