### PR TITLE
Use same letter case as on Crossmint side

### DIFF
--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -127,7 +127,7 @@ export function crossmintModalService({
             if (emailTo) mintQueryParams.emailTo = emailTo;
             if (listingId) mintQueryParams.listingId = listingId;
             if (whPassThroughArgs) mintQueryParams.whPassThroughArgs = JSON.stringify(whPassThroughArgs);
-            if (paymentMethod) mintQueryParams.paymentMethod = paymentMethod;
+            if (paymentMethod) mintQueryParams.paymentMethod = paymentMethod.toLowerCase() as paymentMethods;
             if (preferredSigninMethod) mintQueryParams.preferredSigninMethod = preferredSigninMethod;
 
             return new URLSearchParams(mintQueryParams).toString();

--- a/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
@@ -174,7 +174,7 @@ describe("CrossmintPayButton", () => {
                     fireEvent.click(screen.getByText("Buy with ETH"));
                 });
                 expect(global.open).toHaveBeenCalledWith(
-                    expect.stringContaining("paymentMethod%3DETH"),
+                    expect.stringContaining("paymentMethod%3Deth"),
                     expect.anything(),
                     expect.anything()
                 );
@@ -187,7 +187,7 @@ describe("CrossmintPayButton", () => {
                     fireEvent.click(screen.getByText("Buy with SOL"));
                 });
                 expect(global.open).toHaveBeenCalledWith(
-                    expect.stringContaining("paymentMethod%3DSOL"),
+                    expect.stringContaining("paymentMethod%3Dsol"),
                     expect.anything(),
                     expect.anything()
                 );


### PR DESCRIPTION
I kept the API surface of the button to remain as `ETH`, so its backwards compatible, and then we just make it lowercase in the query params.

Ideally we should probably make a new enum like the `Currency` we have in Crossmint, but it may not be worth it since all client would need to update their buttons if they upgrade package versions