### PR TITLE
Should throw error when mintConfig is not a valid json

### DIFF
--- a/packages/core/base/src/services/crossmintStatusService.ts
+++ b/packages/core/base/src/services/crossmintStatusService.ts
@@ -22,6 +22,15 @@ const validateClientId = (clientId: string): boolean => {
     }
 };
 
+function isJsonString(str: string) {
+    try {
+        JSON.parse(str);
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
 export function crossmintStatusService({
     libVersion,
     clientId,
@@ -32,6 +41,12 @@ export function crossmintStatusService({
     environment,
     clientName,
 }: CrossmintStatusServiceParams) {
+    if (mintConfig != null && typeof mintConfig === "string" && !isJsonString(mintConfig)) {
+        throw new Error(
+            `mintConfig is not a valid json. Check out our docs: https://docs.crossmint.io/docs/payments-introduction`
+        );
+    }
+
     async function fetchClientIntegration() {
         if (!clientId || clientId === "" || clientId === "<YOUR_CLIENT_ID>") {
             console.error("You must enter your own Crossmint client ID in <CrossmintPayButton clientId=XXX>");

--- a/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
@@ -225,4 +225,13 @@ describe("CrossmintPayButton", () => {
             });
         });
     });
+
+    describe("when entering a wrong mint config JSON", () => {
+        const mintConfig = '{"wrong": "json",}' as any;
+        test("should throw an error", () => {
+            expect(() => render(<CrossmintPayButton {...defaultProps} mintConfig={mintConfig} />)).toThrowError(
+                "mintConfig is not a valid json. Check out our docs: https://docs.crossmint.io/docs/payments-introduction"
+            );
+        });
+    });
 });


### PR DESCRIPTION
Requested in https://linear.app/crossmint/issue/ENG-1269/run-json-validation-in-mintconfig-in-button-sdk

We should throw an error when entered mintConfig prop is not a valid json. This will avoid the button to render so this error can be caught up earlier in development.