### PR TITLE
PAY-766 Adding successCallbackURL and failureCallbackURL params to the query params

### DIFF
--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -76,8 +76,7 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
     paymentMethod?: paymentMethods;
     preferredSigninMethod?: SigninMethods;
     prepay?: boolean;
-    layout?: string;
-    successCallbackURL? : string;
+    successCallbackURL?: string;
     failureCallbackURL?: string;
 }
 

--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -36,6 +36,7 @@ export enum onboardingRequestStatusResponse {
     INVALID = "invalid",
 }
 
+
 export interface PayButtonConfig {
     type: string;
 
@@ -75,6 +76,9 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
     paymentMethod?: paymentMethods;
     preferredSigninMethod?: SigninMethods;
     prepay?: boolean;
+    layout?: string;
+    successCallbackURL? : string;
+    failureCallbackURL?: string;
 }
 
 export type OnboardingQueryParams = {

--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -15,6 +15,9 @@ type MintQueryParams = {
     prepay?: string;
     locale: Locale;
     currency: Currency;
+    layout?: string;
+    successCallbackURL? : string;
+    failureCallbackURL?: string;
 };
 
 const overlayId = "__crossmint-overlay__";
@@ -85,6 +88,9 @@ interface CrossmintModalServiceParams {
     clientName: clientNames;
     locale: Locale;
     currency: Currency;
+    layout?: string;
+    successCallbackURL? : string;
+    failureCallbackURL?: string;
 }
 
 export interface CrossmintModalServiceReturn {
@@ -110,6 +116,9 @@ export function crossmintModalService({
                                           clientName,
                                           locale,
                                           currency,
+                                          layout,
+                                          successCallbackURL,
+                                          failureCallbackURL
                                       }: CrossmintModalServiceParams): CrossmintModalServiceReturn {
     const createPopup = (
         mintConfig: PayButtonConfig,
@@ -129,7 +138,7 @@ export function crossmintModalService({
                 clientVersion: libVersion,
                 mintConfig: JSON.stringify(mintConfig),
                 locale,
-                currency,
+                currency
             };
 
             if (mintTo) mintQueryParams.mintTo = mintTo;
@@ -139,6 +148,9 @@ export function crossmintModalService({
             if (paymentMethod) mintQueryParams.paymentMethod = paymentMethod.toLowerCase() as paymentMethods;
             if (preferredSigninMethod) mintQueryParams.preferredSigninMethod = preferredSigninMethod;
             if (prepay) mintQueryParams.prepay = "true";
+            if (layout) mintQueryParams.layout = layout ?? "popUpWindow";
+            if (successCallbackURL) mintQueryParams.successCallbackURL = successCallbackURL;
+            if (failureCallbackURL) mintQueryParams.failureCallbackURL = failureCallbackURL;
 
             return new URLSearchParams(mintQueryParams).toString();
         };

--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -135,7 +135,7 @@ export function crossmintModalService({
                 clientVersion: libVersion,
                 mintConfig: JSON.stringify(mintConfig),
                 locale,
-                currency
+                currency,
             };
 
             if (mintTo) mintQueryParams.mintTo = mintTo;

--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -15,7 +15,6 @@ type MintQueryParams = {
     prepay?: string;
     locale: Locale;
     currency: Currency;
-    layout?: string;
     successCallbackURL? : string;
     failureCallbackURL?: string;
 };
@@ -88,7 +87,6 @@ interface CrossmintModalServiceParams {
     clientName: clientNames;
     locale: Locale;
     currency: Currency;
-    layout?: string;
     successCallbackURL? : string;
     failureCallbackURL?: string;
 }
@@ -116,7 +114,6 @@ export function crossmintModalService({
                                           clientName,
                                           locale,
                                           currency,
-                                          layout,
                                           successCallbackURL,
                                           failureCallbackURL
                                       }: CrossmintModalServiceParams): CrossmintModalServiceReturn {
@@ -148,7 +145,6 @@ export function crossmintModalService({
             if (paymentMethod) mintQueryParams.paymentMethod = paymentMethod.toLowerCase() as paymentMethods;
             if (preferredSigninMethod) mintQueryParams.preferredSigninMethod = preferredSigninMethod;
             if (prepay) mintQueryParams.prepay = "true";
-            if (layout) mintQueryParams.layout = layout ?? "popUpWindow";
             if (successCallbackURL) mintQueryParams.successCallbackURL = successCallbackURL;
             if (failureCallbackURL) mintQueryParams.failureCallbackURL = failureCallbackURL;
 

--- a/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
@@ -41,7 +41,7 @@ describe("CrossmintPayButton", () => {
         expect(global.open).toHaveBeenCalledWith(
             `https://www.crossmint.io/signin?callbackUrl=https%3A%2F%2Fwww.crossmint.io%2Fcheckout%2Fmint%3FclientId%3D${encodeURIComponent(
                 defaultProps.clientId
-            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26locale%3Den-US%26currency%3DUSD`,
+            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26locale%3Den-US%26currency%3DUSD%26layout%3DpopUpWindow%26successCallbackURL%3Dwww.crossmint.io`,
             "popUpWindow",
             "height=750,width=400,left=312,top=9,resizable=yes,scrollbars=yes,toolbar=yes,menubar=true,location=no,directories=no, status=yes"
         );

--- a/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
@@ -41,7 +41,7 @@ describe("CrossmintPayButton", () => {
         expect(global.open).toHaveBeenCalledWith(
             `https://www.crossmint.io/signin?callbackUrl=https%3A%2F%2Fwww.crossmint.io%2Fcheckout%2Fmint%3FclientId%3D${encodeURIComponent(
                 defaultProps.clientId
-            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26locale%3Den-US%26currency%3DUSD&locale=en-US&currency=USD%26layout%3DpopUpWindow%26successCallbackURL%3Dwww.crossmint.io`,
+            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26locale%3Den-US%26currency%3DUSD`,
             "popUpWindow",
             "height=750,width=400,left=312,top=9,resizable=yes,scrollbars=yes,toolbar=yes,menubar=true,location=no,directories=no, status=yes"
         );

--- a/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
@@ -41,7 +41,7 @@ describe("CrossmintPayButton", () => {
         expect(global.open).toHaveBeenCalledWith(
             `https://www.crossmint.io/signin?callbackUrl=https%3A%2F%2Fwww.crossmint.io%2Fcheckout%2Fmint%3FclientId%3D${encodeURIComponent(
                 defaultProps.clientId
-            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26locale%3Den-US%26currency%3DUSD`,
+            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26`,
             "popUpWindow",
             "height=750,width=400,left=312,top=9,resizable=yes,scrollbars=yes,toolbar=yes,menubar=true,location=no,directories=no, status=yes"
         );

--- a/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
@@ -41,7 +41,7 @@ describe("CrossmintPayButton", () => {
         expect(global.open).toHaveBeenCalledWith(
             `https://www.crossmint.io/signin?callbackUrl=https%3A%2F%2Fwww.crossmint.io%2Fcheckout%2Fmint%3FclientId%3D${encodeURIComponent(
                 defaultProps.clientId
-            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26`,
+            )}%26clientName%3Dclient-sdk-react-ui%26clientVersion%3D${LIB_VERSION}%26mintConfig%3D%257B%2522type%2522%253A%2522candy-machine%2522%257D%26locale%3Den-US%26currency%3DUSD&locale=en-US&currency=USD`,
             "popUpWindow",
             "height=750,width=400,left=312,top=9,resizable=yes,scrollbars=yes,toolbar=yes,menubar=true,location=no,directories=no, status=yes"
         );

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -42,8 +42,8 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
     prepay,
     locale = "en-US",
     currency = "USD",
-    layout = "popUpWindow",
-    successCallbackURL = "https://www.crossmint.com/console/",
+    layout = "",
+    successCallbackURL = "",
     failureCallbackURL = "",
     ...props
   }) => {

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -42,6 +42,9 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
     prepay,
     locale = "en-US",
     currency = "USD",
+    layout = "popUpWindow",
+    successCallbackURL = "https://www.crossmint.com/console/",
+    failureCallbackURL = "",
     ...props
   }) => {
     const [connecting, setConnecting] = useState(false);
@@ -68,6 +71,9 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
         clientName: clientNames.reactUi,
         locale,
         currency,
+        layout,
+        successCallbackURL,
+        failureCallbackURL,
     });
 
     const { getButtonText, shouldHideButton, handleClick } = crossmintPayButtonService({

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -42,7 +42,6 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
     prepay,
     locale = "en-US",
     currency = "USD",
-    layout = "",
     successCallbackURL = "",
     failureCallbackURL = "",
     ...props
@@ -71,7 +70,6 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
         clientName: clientNames.reactUi,
         locale,
         currency,
-        layout,
         successCallbackURL,
         failureCallbackURL,
     });

--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -39,7 +39,6 @@ const propertyDefaults: CrossmintPayButtonLitProps = {
     prepay: false,
     locale: "en-US",
     currency: "USD",
-    layout: "popUpWindow",
     successCallbackURL: "",
     failureCallbackURL: ""
 };
@@ -106,9 +105,6 @@ export class CrossmintPayButton extends LitElement {
     currency = propertyDefaults.currency;
 
     @property({ type: String })
-    layout = propertyDefaults.layout;
-
-    @property({ type: String })
     successCallbackURL = propertyDefaults.successCallbackURL;
 
     @property({ type: String })
@@ -173,7 +169,6 @@ export class CrossmintPayButton extends LitElement {
             clientName: clientNames.vanillaUi,
             locale: this.locale || "en-US",
             currency: this.currency || "USD",
-            layout: this.layout || "popUpWindow",
             successCallbackURL: this.successCallbackURL ,
             failureCallbackURL: this.failureCallbackURL,
         });
@@ -189,7 +184,6 @@ export class CrossmintPayButton extends LitElement {
                     this.paymentMethod,
                     this.preferredSigninMethod,
                     this.prepay,
-                    this.layout,
                     this.successCallbackURL,
                     this.failureCallbackURL,
                 );

--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -39,6 +39,9 @@ const propertyDefaults: CrossmintPayButtonLitProps = {
     prepay: false,
     locale: "en-US",
     currency: "USD",
+    layout: "popUpWindow",
+    successCallbackURL: "",
+    failureCallbackURL: ""
 };
 
 @customElement("crossmint-pay-button")
@@ -102,6 +105,15 @@ export class CrossmintPayButton extends LitElement {
     @property({ type: String })
     currency = propertyDefaults.currency;
 
+    @property({ type: String })
+    layout = propertyDefaults.layout;
+
+    @property({ type: String })
+    successCallbackURL = propertyDefaults.successCallbackURL;
+
+    @property({ type: String })
+    failureCallbackURL = propertyDefaults.failureCallbackURL;
+
     static styles = buttonStyles;
 
     connecting = false;
@@ -161,6 +173,9 @@ export class CrossmintPayButton extends LitElement {
             clientName: clientNames.vanillaUi,
             locale: this.locale || "en-US",
             currency: this.currency || "USD",
+            layout: this.layout || "popUpWindow",
+            successCallbackURL: this.successCallbackURL ,
+            failureCallbackURL: this.failureCallbackURL,
         });
 
         const _handleClick = (e: any) =>
@@ -174,6 +189,9 @@ export class CrossmintPayButton extends LitElement {
                     this.paymentMethod,
                     this.preferredSigninMethod,
                     this.prepay,
+                    this.layout,
+                    this.successCallbackURL,
+                    this.failureCallbackURL,
                 );
             });
 


### PR DESCRIPTION
This PR adds the PAY-766 Adding `successCallbackURL` and `failureCallbackURL` params to the query params.
It was tested with the test UI starter project.

