### PR TITLE
Change wallet UI api

### DIFF
--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -105,7 +105,6 @@ interface UIConfig {
 }
 
 interface CommonProps {
-    projectId: string;
     uiConfig?: UIConfig;
     environment?: string;
 }

--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -88,7 +88,7 @@ export type OnboardingQueryParams = {
 
 export interface Wallet {
     chain: string;
-    address: string;
+    publicKey: string;
 }
 
 interface Colors {

--- a/packages/core/base/src/utils/ui.ts
+++ b/packages/core/base/src/utils/ui.ts
@@ -47,12 +47,11 @@ function getNFTLocator(address: string, chain: string, tokenId?: string): string
 
 export function getNFTCollectionViewSrc(props: NFTCollectionViewProps, clientVersion: string) {
     const baseUrl = getEnvironmentBaseUrl(props.environment);
-    const { wallets, projectId } = props;
+    const { wallets } = props;
     const walletsStringify = JSON.stringify(wallets);
 
     const queryParams = new URLSearchParams({
         wallets: walletsStringify,
-        projectId,
         clientVersion,
         ...(props.uiConfig != null ? { uiConfig: JSON.stringify(props.uiConfig) } : {}),
     });
@@ -61,9 +60,7 @@ export function getNFTCollectionViewSrc(props: NFTCollectionViewProps, clientVer
 
 export function getNFTDetailSrc(props: NFTDetailProps, clientVersion: string) {
     const baseUrl = getEnvironmentBaseUrl(props.environment);
-    const { projectId } = props;
     const queryParams = new URLSearchParams({
-        projectId,
         clientVersion,
         ...(props.uiConfig != null ? { uiConfig: JSON.stringify(props.uiConfig) } : {}),
     });

--- a/packages/core/base/src/utils/validate.ts
+++ b/packages/core/base/src/utils/validate.ts
@@ -1,16 +1,12 @@
 import { NFTCollectionViewProps, NFTDetailProps } from "../models/types";
 
-export function assertValidNFTCollectionViewProps({ wallets, projectId }: NFTCollectionViewProps) {
+export function assertValidNFTCollectionViewProps({ wallets }: NFTCollectionViewProps) {
     if (wallets.length === 0) {
         throw new Error("wallets prop is empty. Please provide at least one wallet.");
     }
-
-    if (!projectId) {
-        throw new Error("projectId prop is empty. Please provide a valid projectId.");
-    }
 }
 
-export function assertValidValidateNFTDetailProps({ nft, projectId }: NFTDetailProps) {
+export function assertValidValidateNFTDetailProps({ nft }: NFTDetailProps) {
     if (nft == null) {
         throw new Error("nft prop is empty. Please provide a valid nft.");
     }

--- a/packages/core/base/src/utils/validateUUID.ts
+++ b/packages/core/base/src/utils/validateUUID.ts
@@ -1,24 +1,6 @@
-import { NFTCollectionViewProps, NFTDetailProps } from "../models/types";
-
 const REGEX =
     /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
 export default function validate(uuid: string) {
     return typeof uuid === "string" && REGEX.test(uuid);
-}
-
-export function assertValidNFTCollectionViewProps({ wallets, projectId }: NFTCollectionViewProps) {
-    if (wallets.length === 0) {
-        throw new Error("wallets prop is empty. Please provide at least one wallet.");
-    }
-
-    if (!projectId) {
-        throw new Error("projectId prop is empty. Please provide a valid projectId.");
-    }
-}
-
-export function assertValidValidateNFTDetailProps({ nft, projectId }: NFTDetailProps) {
-    if (nft == null) {
-        throw new Error("nft prop is empty. Please provide a valid nft.");
-    }
 }

--- a/packages/ui/react-ui/__tests__/CrossmintCollectionView.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintCollectionView.spec.tsx
@@ -8,18 +8,17 @@ const wallets = [{ chain: "solana", publicKey: "12345" }];
 
 describe("when only passing mandatory fields", () => {
     test("should add them to the iframe query params", () => {
-        render(<CrossmintNFTCollectionView wallets={wallets} projectId="12345" />);
+        render(<CrossmintNFTCollectionView wallets={wallets} />);
         const iframe = screen.getByRole("nft-collection-view");
         const src = iframe.getAttribute("src");
         expect(src).toContain("wallets=%5B%7B%22chain%22%3A%22solana%22%2C%22publicKey%22%3A%2212345%22%7D%5D");
-        expect(src).toContain("projectId=12345");
         expect(src).toContain("clientVersion=");
     });
 });
 
 describe("when not setting any environment", () => {
     test("should default to production", () => {
-        render(<CrossmintNFTCollectionView wallets={wallets} projectId="12345" />);
+        render(<CrossmintNFTCollectionView wallets={wallets} />);
         const iframe = screen.getByRole("nft-collection-view");
         const src = iframe.getAttribute("src");
         expect(src).toContain("https://www.crossmint.com/");
@@ -28,7 +27,7 @@ describe("when not setting any environment", () => {
 
 describe("when setting the environment to staging", () => {
     test("should use the staging url", () => {
-        render(<CrossmintNFTCollectionView wallets={wallets} projectId="12345" environment="staging" />);
+        render(<CrossmintNFTCollectionView wallets={wallets} environment="staging" />);
         const iframe = screen.getByRole("nft-collection-view");
         const src = iframe.getAttribute("src");
         expect(src).toContain("https://staging.crossmint.com/");

--- a/packages/ui/react-ui/__tests__/CrossmintCollectionView.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintCollectionView.spec.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import { CrossmintNFTCollectionView } from "../src/CrossmintNFTCollectionView";
 
-const wallets = [{ chain: "solana", address: "12345" }];
+const wallets = [{ chain: "solana", publicKey: "12345" }];
 
 describe("when only passing mandatory fields", () => {
     test("should add them to the iframe query params", () => {

--- a/packages/ui/react-ui/__tests__/CrossmintCollectionView.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintCollectionView.spec.tsx
@@ -11,7 +11,7 @@ describe("when only passing mandatory fields", () => {
         render(<CrossmintNFTCollectionView wallets={wallets} projectId="12345" />);
         const iframe = screen.getByRole("nft-collection-view");
         const src = iframe.getAttribute("src");
-        expect(src).toContain("wallets=%5B%7B%22chain%22%3A%22solana%22%2C%22address%22%3A%2212345%22%7D%5D");
+        expect(src).toContain("wallets=%5B%7B%22chain%22%3A%22solana%22%2C%22publicKey%22%3A%2212345%22%7D%5D");
         expect(src).toContain("projectId=12345");
         expect(src).toContain("clientVersion=");
     });

--- a/packages/ui/react-ui/__tests__/CrossmintNFTDetail.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintNFTDetail.spec.tsx
@@ -8,18 +8,17 @@ const nft = { chain: "ethereum", address: "0x12345", tokenId: "12" };
 
 describe("when only passing mandatory fields", () => {
     test("should add them to the iframe query params", () => {
-        render(<CrossmintNFTDetail nft={nft} projectId="12345" />);
+        render(<CrossmintNFTDetail nft={nft} />);
         const iframe = screen.getByRole("nft-details");
         const src = iframe.getAttribute("src");
         expect(src).toContain("/sdk/wallets/tokens/eth:0x12345:12");
-        expect(src).toContain("projectId=12345");
         expect(src).toContain("clientVersion=");
     });
 });
 
 describe("when not setting any environment", () => {
     test("should default to production", () => {
-        render(<CrossmintNFTDetail nft={nft} projectId="12345" />);
+        render(<CrossmintNFTDetail nft={nft} />);
         const iframe = screen.getByRole("nft-details");
         const src = iframe.getAttribute("src");
         expect(src).toContain("https://www.crossmint.com/");
@@ -28,7 +27,7 @@ describe("when not setting any environment", () => {
 
 describe("when setting the environment to staging", () => {
     test("should use the staging url", () => {
-        render(<CrossmintNFTDetail nft={nft} projectId="12345" environment="staging" />);
+        render(<CrossmintNFTDetail nft={nft} environment="staging" />);
         const iframe = screen.getByRole("nft-details");
         const src = iframe.getAttribute("src");
         expect(src).toContain("https://staging.crossmint.com/");


### PR DESCRIPTION
A few changes here:
- In the walletCollection view, in the wallets interface, replace address for `publicKey`, which is what is return in our endpoint.
- Remove the projectId everywhere as requested by @alfonso-paella (https://crossmint.slack.com/archives/C04SF1PBR7W/p1678769820170049)

Not changing anything about the nft interface, since I want it to be the same for all nfts regarding the chain.