### PR TITLE
Using chain names for NFT locators

### DIFF
--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -1,5 +1,7 @@
 export const EVM_CHAINS = ["ethereum", "polygon", "bsc"] as const;
+export const ALL_CHAINS = ["solana", "cardano", ...EVM_CHAINS] as const;
 export type EVMChain = (typeof EVM_CHAINS)[number];
+export type Blockchain = (typeof ALL_CHAINS)[number];
 
 export enum clientNames {
     reactUi = "client-sdk-react-ui",
@@ -16,15 +18,6 @@ export enum customHeaders {
     clientVersion = "X-Client-Version",
     clientName = "X-Client-Name",
 }
-
-export enum ChainLocators {
-    solana = "sol",
-    ethereum = "eth",
-    polygon = "poly",
-    cardano = "ada",
-    bsc = "bsc",
-}
-export type EVMChainLocators = ChainLocators.bsc | ChainLocators.ethereum | ChainLocators.polygon;
 
 type theme = "light" | "dark";
 
@@ -141,17 +134,17 @@ export interface SolanaNFT {
     chain: "solana";
 }
 
-export type NFTLocator<T extends ChainLocators> = `${T}:${string}${T extends EVMChainLocators ? `:${string}` : ""}`;
+export type NFTLocator<T extends Blockchain> = `${T}:${string}${T extends EVMChain ? `:${string}` : ""}`;
 
 export type NFT =
     | CardanoNFT
     | EVMNFT
     | SolanaNFT
-    | NFTLocator<ChainLocators.solana>
-    | NFTLocator<ChainLocators.ethereum>
-    | NFTLocator<ChainLocators.polygon>
-    | NFTLocator<ChainLocators.bsc>
-    | NFTLocator<ChainLocators.cardano>;
+    | NFTLocator<"solana">
+    | NFTLocator<"ethereum">
+    | NFTLocator<"polygon">
+    | NFTLocator<"bsc">
+    | NFTLocator<"cardano">;
 
 export interface NFTDetailProps extends CommonProps {
     nft: NFT;

--- a/packages/core/base/src/utils/ui.ts
+++ b/packages/core/base/src/utils/ui.ts
@@ -1,4 +1,4 @@
-import { ChainLocators, NFT, NFTCollectionViewProps, NFTDetailProps, baseUrls } from "../models/types";
+import { NFT, NFTCollectionViewProps, NFTDetailProps, baseUrls } from "../models/types";
 
 export const getEnvironmentBaseUrl = (environment = ""): string => {
     const productionValues = ["prod", "production"];
@@ -14,13 +14,13 @@ function getNFTLocator(nft: NFT) {
 
     switch (nft.chain) {
         case "solana":
-            return `${ChainLocators.solana}:${nft.mintHash}`;
+            return `${nft.chain}:${nft.mintHash}`;
         case "polygon":
         case "ethereum":
         case "bsc":
-            return `${ChainLocators[nft.chain]}:${nft.contractAddress}:${nft.tokenId}`;
+            return `${nft.chain}:${nft.contractAddress}:${nft.tokenId}`;
         case "cardano":
-            return `${ChainLocators[nft.chain]}:${nft.assetId}`;
+            return `${nft.chain}:${nft.assetId}`;
         default:
             throw new Error(`Invalid chain type ${JSON.stringify(nft)}`);
     }

--- a/packages/ui/react-ui/__tests__/CrossmintNFTDetail.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintNFTDetail.spec.tsx
@@ -13,7 +13,7 @@ describe("when only passing mandatory fields", () => {
         render(<CrossmintNFTDetail nft={nft} />);
         const iframe = screen.getByRole("nft-details");
         const src = iframe.getAttribute("src");
-        expect(src).toContain("/sdk/wallets/tokens/eth:0x12345:12");
+        expect(src).toContain("/sdk/wallets/tokens/ethereum:0x12345:12");
         expect(src).toContain("clientVersion=");
     });
 });


### PR DESCRIPTION
Using chain names instead of shortened versions for NFT locator:

`sol:1235` -> `solana:12345`