### PR TITLE
Add on event prop

### DIFF
--- a/packages/core/base/src/index.ts
+++ b/packages/core/base/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./utils/index";
 export * from "./models/types";
+export * from "./models/events";
 export * from "./services/crossmintModalService";
 export * from "./services/crossmintPayButtonService";
 export * from "./services/crossmintStatusService";

--- a/packages/core/base/src/models/events.ts
+++ b/packages/core/base/src/models/events.ts
@@ -1,5 +1,7 @@
 export enum CheckoutEvents {
     PAYMENT_READY = "payment:ready",
+    PAYMENT_STARTED = "payment:started",
+    PAYMENT_FAILED = "payment:failed",
     PAYMENT_COMPLETED = "payment:completed",
     PAYMENT_CANCELED = "payment:canceled",
     PAYMENT_REJECTED = "payment:rejected",

--- a/packages/core/base/src/models/events.ts
+++ b/packages/core/base/src/models/events.ts
@@ -1,0 +1,9 @@
+export enum CheckoutEvents {
+    PAYMENT_READY = "payment:ready",
+    PAYMENT_COMPLETED = "payment:completed",
+    PAYMENT_CANCELED = "payment:canceled",
+    PAYMENT_REJECTED = "payment:rejected",
+    MINTING_STARTED = "minting:started",
+    MINTING_COMPLETED = "minting:completed",
+    MINTING_FAILED = "minting:failed",
+}

--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -68,7 +68,6 @@ export interface BaseButtonProps {
     environment?: string;
     locale?: Locale;
     currency?: Currency;
-    onEvent?: (event: CheckoutEvents, metadata?: any) => void;
 }
 
 export interface CrossmintPayButtonProps extends BaseButtonProps {
@@ -85,6 +84,7 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
     prepay?: boolean;
     successCallbackURL?: string;
     failureCallbackURL?: string;
+    onEvent?: (event: CheckoutEvents, metadata?: any) => void;
 }
 
 export type OnboardingQueryParams = {

--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -1,3 +1,5 @@
+import { CheckoutEvents } from "./events";
+
 export const EVM_CHAINS = ["ethereum", "polygon", "bsc"] as const;
 export const ALL_CHAINS = ["solana", "cardano", ...EVM_CHAINS] as const;
 export type EVMChain = (typeof EVM_CHAINS)[number];
@@ -66,6 +68,7 @@ export interface BaseButtonProps {
     environment?: string;
     locale?: Locale;
     currency?: Currency;
+    onEvent?: (event: CheckoutEvents, metadata?: any) => void;
 }
 
 export interface CrossmintPayButtonProps extends BaseButtonProps {

--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -84,7 +84,8 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
     prepay?: boolean;
     successCallbackURL?: string;
     failureCallbackURL?: string;
-    onEvent?: (event: CheckoutEvents, metadata?: Record<string, any>) => void;
+    // TODO: Enable when events are ready in crossbit-main and docs are updated
+    // onEvent?: (event: CheckoutEvents, metadata?: Record<string, any>) => void;
 }
 
 export type OnboardingQueryParams = {

--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -84,7 +84,7 @@ export interface CrossmintPayButtonProps extends BaseButtonProps {
     prepay?: boolean;
     successCallbackURL?: string;
     failureCallbackURL?: string;
-    onEvent?: (event: CheckoutEvents, metadata?: any) => void;
+    onEvent?: (event: CheckoutEvents, metadata?: Record<string, any>) => void;
 }
 
 export type OnboardingQueryParams = {

--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -90,7 +90,8 @@ interface CrossmintModalServiceParams {
     currency: Currency;
     successCallbackURL?: string;
     failureCallbackURL?: string;
-    onEvent?: (event: CheckoutEvents, metadata?: any) => void;
+    // TODO: Enable when events are ready in crossbit-main and docs are updated
+    // onEvent?: (event: CheckoutEvents, metadata?: any) => void;
 }
 
 export interface CrossmintModalServiceReturn {
@@ -118,7 +119,6 @@ export function crossmintModalService({
     currency,
     successCallbackURL,
     failureCallbackURL,
-    onEvent,
 }: CrossmintModalServiceParams): CrossmintModalServiceReturn {
     const createPopup = (
         mintConfig: PayButtonConfig,
@@ -211,9 +211,10 @@ export function crossmintModalService({
                 return;
             }
 
-            if (onEvent != null) {
+            // TODO: Enable when events are ready in crossbit-main and docs are updated
+            /* if (onEvent != null) {
                 onEvent(message.data.name, message.data);
-            }
+            } */
         });
     }
 

--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -1,4 +1,5 @@
-import { PayButtonConfig, SigninMethods, clientNames, paymentMethods, Locale, Currency } from "../models/types";
+import { CheckoutEvents } from "../models/events";
+import { Currency, Locale, PayButtonConfig, SigninMethods, clientNames, paymentMethods } from "../models/types";
 import { getEnvironmentBaseUrl } from "../utils/ui";
 
 type MintQueryParams = {
@@ -15,7 +16,7 @@ type MintQueryParams = {
     prepay?: string;
     locale: Locale;
     currency: Currency;
-    successCallbackURL? : string;
+    successCallbackURL?: string;
     failureCallbackURL?: string;
 };
 
@@ -87,8 +88,9 @@ interface CrossmintModalServiceParams {
     clientName: clientNames;
     locale: Locale;
     currency: Currency;
-    successCallbackURL? : string;
+    successCallbackURL?: string;
     failureCallbackURL?: string;
+    onEvent?: (event: CheckoutEvents, metadata?: any) => void;
 }
 
 export interface CrossmintModalServiceReturn {
@@ -100,23 +102,24 @@ export interface CrossmintModalServiceReturn {
         whPassThroughArgs?: any,
         paymentMethod?: paymentMethods,
         preferredSigninMethod?: SigninMethods,
-        prepay?: boolean,
+        prepay?: boolean
     ) => void;
 }
 
 export function crossmintModalService({
-                                          clientId,
-                                          libVersion,
-                                          showOverlay,
-                                          dismissOverlayOnClick,
-                                          setConnecting,
-                                          environment,
-                                          clientName,
-                                          locale,
-                                          currency,
-                                          successCallbackURL,
-                                          failureCallbackURL
-                                      }: CrossmintModalServiceParams): CrossmintModalServiceReturn {
+    clientId,
+    libVersion,
+    showOverlay,
+    dismissOverlayOnClick,
+    setConnecting,
+    environment,
+    clientName,
+    locale,
+    currency,
+    successCallbackURL,
+    failureCallbackURL,
+    onEvent,
+}: CrossmintModalServiceParams): CrossmintModalServiceReturn {
     const createPopup = (
         mintConfig: PayButtonConfig,
         mintTo?: string,
@@ -125,7 +128,7 @@ export function crossmintModalService({
         whPassThroughArgs?: any,
         paymentMethod?: paymentMethods,
         preferredSigninMethod?: SigninMethods,
-        prepay?: boolean,
+        prepay?: boolean
     ) => {
         const urlOrigin = getEnvironmentBaseUrl(environment);
         const getMintQueryParams = (): string => {
@@ -176,7 +179,7 @@ export function crossmintModalService({
         whPassThroughArgs?: any,
         paymentMethod?: paymentMethods,
         preferredSigninMethod?: SigninMethods,
-        prepay?: boolean,
+        prepay?: boolean
     ) => {
         setConnecting(true);
 
@@ -188,12 +191,12 @@ export function crossmintModalService({
             whPassThroughArgs,
             paymentMethod,
             preferredSigninMethod,
-            prepay,
+            prepay
         );
     };
 
     function registerListeners(pop: Window) {
-        const timer = setInterval(function() {
+        const timer = setInterval(function () {
             if (pop.closed) {
                 clearInterval(timer);
                 setConnecting(false);
@@ -202,6 +205,16 @@ export function crossmintModalService({
                 }
             }
         }, 500);
+
+        window.addEventListener("message", (message) => {
+            if (message.origin !== getEnvironmentBaseUrl(environment)) {
+                return;
+            }
+
+            if (onEvent != null) {
+                onEvent(message.data.name, message.data);
+            }
+        });
     }
 
     return {

--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -196,17 +196,7 @@ export function crossmintModalService({
     };
 
     function registerListeners(pop: Window) {
-        const timer = setInterval(function () {
-            if (pop.closed) {
-                clearInterval(timer);
-                setConnecting(false);
-                if (showOverlay) {
-                    removeLoadingOverlay();
-                }
-            }
-        }, 500);
-
-        window.addEventListener("message", (message) => {
+        function messageEventListener(message: MessageEvent<any>) {
             if (message.origin !== getEnvironmentBaseUrl(environment)) {
                 return;
             }
@@ -215,7 +205,20 @@ export function crossmintModalService({
             /* if (onEvent != null) {
                 onEvent(message.data.name, message.data);
             } */
-        });
+        }
+
+        const timer = setInterval(function () {
+            if (pop.closed) {
+                clearInterval(timer);
+                setConnecting(false);
+                if (showOverlay) {
+                    removeLoadingOverlay();
+                }
+                window.removeEventListener("message", messageEventListener);
+            }
+        }, 500);
+
+        window.addEventListener("message", messageEventListener);
     }
 
     return {

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -45,7 +45,7 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
     successCallbackURL = "",
     failureCallbackURL = "",
     ...props
-  }) => {
+}) => {
     const [connecting, setConnecting] = useState(false);
     const [status, setStatus] = useState(onboardingRequestStatusResponse.WAITING_SUBMISSION);
     const { isServerSideRendering } = useEnvironment();
@@ -72,6 +72,7 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
         currency,
         successCallbackURL,
         failureCallbackURL,
+        onEvent: props.onEvent,
     });
 
     const { getButtonText, shouldHideButton, handleClick } = crossmintPayButtonService({
@@ -97,7 +98,7 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
                 whPassThroughArgs,
                 paymentMethod,
                 preferredSigninMethod,
-                prepay,
+                prepay
             );
         });
 

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -72,7 +72,6 @@ export const CrossmintPayButton: FC<CrossmintPayButtonReactProps> = ({
         currency,
         successCallbackURL,
         failureCallbackURL,
-        onEvent: props.onEvent,
     });
 
     const { getButtonText, shouldHideButton, handleClick } = crossmintPayButtonService({

--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -40,7 +40,8 @@ const propertyDefaults: CrossmintPayButtonLitProps = {
     locale: "en-US",
     currency: "USD",
     successCallbackURL: "",
-    failureCallbackURL: ""
+    failureCallbackURL: "",
+    onEvent: undefined,
 };
 
 @customElement("crossmint-pay-button")
@@ -110,6 +111,9 @@ export class CrossmintPayButton extends LitElement {
     @property({ type: String })
     failureCallbackURL = propertyDefaults.failureCallbackURL;
 
+    @property({ type: Function })
+    onEvent = propertyDefaults.onEvent;
+
     static styles = buttonStyles;
 
     connecting = false;
@@ -171,6 +175,7 @@ export class CrossmintPayButton extends LitElement {
             currency: this.currency || "USD",
             successCallbackURL: this.successCallbackURL ,
             failureCallbackURL: this.failureCallbackURL,
+            onEvent: this.onEvent,
         });
 
         const _handleClick = (e: any) =>

--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -41,7 +41,6 @@ const propertyDefaults: CrossmintPayButtonLitProps = {
     currency: "USD",
     successCallbackURL: "",
     failureCallbackURL: "",
-    onEvent: undefined,
 };
 
 @customElement("crossmint-pay-button")
@@ -111,9 +110,6 @@ export class CrossmintPayButton extends LitElement {
     @property({ type: String })
     failureCallbackURL = propertyDefaults.failureCallbackURL;
 
-    @property({ type: Function })
-    onEvent = propertyDefaults.onEvent;
-
     static styles = buttonStyles;
 
     connecting = false;
@@ -175,7 +171,6 @@ export class CrossmintPayButton extends LitElement {
             currency: this.currency || "USD",
             successCallbackURL: this.successCallbackURL ,
             failureCallbackURL: this.failureCallbackURL,
-            onEvent: this.onEvent,
         });
 
         const _handleClick = (e: any) =>


### PR DESCRIPTION
This PR does two things:

- Adds an events type with all checkout events.
- Watches from events sent from the popover (crossbit-main).

That way, users will be able to subscribe to events that we will sent in different stages of the mint.

See demo:
https://www.loom.com/share/ee069a333abc4659a70bc82e7dfa2d50