### PR TITLE
Add generic transaction failure error

### DIFF
--- a/packages/core/base/src/models/errors.ts
+++ b/packages/core/base/src/models/errors.ts
@@ -21,6 +21,7 @@ export const PaymentErrors = {
     PAYMENT_REJECTED_CARD_INCORRECT_CVC: "payments:payment-rejected.card-incorrect-cvc",
     PAYMENT_REJECTED_PROCESSING_ERROR: "payments:payment-rejected.processing-error",
     PAYMENT_REJECTED_CARD_INCORRECT_NUMBER: "payments:payment-rejected.card-incorrect-number",
+    TRANSACTION_ERROR_GENERIC: "payments:transaction-error.generic",
 } as const;
 export type PaymentErrors = (typeof PaymentErrors)[keyof typeof PaymentErrors];
 


### PR DESCRIPTION
Adding a generic error for transaction failure for now.

More context here: https://crossmint.slack.com/archives/C04SC413XMZ/p1680177719188949