### PR TITLE
feat: Adds VSCode workspace file

### DIFF
--- a/crossmint-client-sdk.code-workspace
+++ b/crossmint-client-sdk.code-workspace
@@ -1,0 +1,32 @@
+{
+    "folders": [
+        {
+            "name": "🌿 @crossmint/client-sdk",
+            "path": "."
+        },
+        {
+            "name": "🧬 @crossmint/client-sdk-base",
+            "path": "packages/core/base"
+        },
+        {
+            "name": "⚛️ @crossmint/client-sdk-react-ui",
+            "path": "packages/ui/react-ui"
+        },
+        {
+            "name": "⚪ @crossmint/client-sdk-vanilla-ui",
+            "path": "packages/ui/vanilla-ui"
+        },
+        {
+            "name": "🟢 @crossmint/client-sdk-vue-ui",
+            "path": "packages/ui/vue-ui"
+        },
+        {
+            "name": "🏁 Starters",
+            "path": "packages/starter"
+        }
+    ],
+    "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
+}


### PR DESCRIPTION
Completely optional to use, but if u want this interface all you have to do is open the `crossmint-client-sdk.code-workspace` file

If you dont want to use it, you just continue to use your vscode as you normally do

imo, makes it significantly easier to browse the repo tho


<img width="350" alt="image" src="https://user-images.githubusercontent.com/93682696/229690002-f0424dba-7f9a-4de6-9b06-a4caecfcfd47.png">


<img width="350" alt="image" src="https://user-images.githubusercontent.com/93682696/229689976-b8e45c5f-ad1b-4f8b-a092-d74c983bfc03.png">

When you open a terminal you also get to select which scope to open it in, so it saves you a bunch of `cd`ing to the correct directory
<img width="450" alt="image" src="https://user-images.githubusercontent.com/93682696/229690802-c76d7f01-7d3e-4249-9fb9-fc3b9421d3ac.png">

