### PR TITLE
fix: iframe do not show until loaded

### DIFF
--- a/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
+++ b/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
@@ -63,7 +63,8 @@ watch(
         :src="iframeUrl"
         allow="payment *"
         id="iframe-crossmint-payment-element"
-        :style="{ height: `${styleHeight}px` }"
+        :style="{ height: `${styleHeight}px`, display: 'none' }"
+        :onload="this.style.display = 'block';" 
     ></iframe>
 </template>
 


### PR DESCRIPTION
https://linear.app/crossmint/issue/PAY-1087/glitch-when-loading-iframe

If possible, we'd love this functionality!

https://devsheet.com/code-snippet/show-iframe-only-after-fully-loaded-in-html/

Is there a good way to test locally? `yarn dev` didn't pull anything up for me...