### PR TITLE
Add payment method type to order finished event paylod

### DIFF
--- a/packages/core/base/src/models/paymentElement.ts
+++ b/packages/core/base/src/models/paymentElement.ts
@@ -85,11 +85,20 @@ interface TransactionFulfillmentFailed extends TransactionBase {
 
 type Verification = { required: false } | { required: true; url: string };
 
+export const PaymentMethodType = {
+    // TODO: Think granularity for crypto payments
+    CREDIT_CARD: "credit-card",
+    GOOGLE_PAY: "google-pay",
+    APPLE_PAY: "apple-pay",
+} as const;
+export type PaymentMethodType = (typeof PaymentMethodType)[keyof typeof PaymentMethodType];
+
 interface OrderProcessFinished {
     successfulTransactionIdentifiers: string[];
     failedTransactionIdentifiers: string[];
     verification: Verification;
     totalPrice: FiatPrice;
+    paymentMethodType: PaymentMethodType;
 }
 
 interface RecipientWalletChanged {


### PR DESCRIPTION
Adding a new field `paymentMethodType` with three possible values for now:
`credit-card`, `google-pay` and `apple-pay`

We will need to think in the future what values this field will take for crypto payments. But for now, I'd say we are good.