### PR TITLE
Remove event listener support

### DIFF
--- a/packages/core/base/src/services/crossmintPaymentService.ts
+++ b/packages/core/base/src/services/crossmintPaymentService.ts
@@ -44,8 +44,8 @@ export function crossmintPaymentService({
 
     function listenToEvents(
         cb: <K extends keyof CheckoutEventMap>(event: MessageEvent<CrossmintCheckoutEvent<K>>) => void
-    ) {
-        window.addEventListener("message", (event) => {
+    ): () => void {
+        function _internalOnEvent(event: MessageEvent<any>) {
             if (event.origin !== baseUrl) {
                 return;
             }
@@ -53,7 +53,13 @@ export function crossmintPaymentService({
             if (Object.values(CheckoutEvents).includes(event.data.type)) {
                 cb(event);
             }
-        });
+        }
+
+        window.addEventListener("message", _internalOnEvent);
+
+        return () => {
+            window.removeEventListener("message", _internalOnEvent);
+        }
     }
 
     function emitQueryParams(payload: ParamsUpdatePayload) {

--- a/packages/core/base/src/services/crossmintUiService.ts
+++ b/packages/core/base/src/services/crossmintUiService.ts
@@ -1,11 +1,11 @@
-import { UiEvents } from "../models/events";
-import { getEnvironmentBaseUrl } from "../utils";
+import {UiEvents} from "../models/events";
+import {getEnvironmentBaseUrl} from "../utils";
 
-export function crossmintUiService({ environment }: { environment?: string } = {}) {
+export function crossmintUiService({environment}: { environment?: string } = {}) {
     const baseUrl = getEnvironmentBaseUrl(environment);
 
-    function listenToEvents(cb: (event: MessageEvent) => void) {
-        window.addEventListener("message", (event) => {
+    function listenToEvents(cb: (event: MessageEvent) => void): () => void {
+        function _internalOnEvent(event: MessageEvent<any>) {
             if (event.origin !== baseUrl) {
                 return;
             }
@@ -13,7 +13,13 @@ export function crossmintUiService({ environment }: { environment?: string } = {
             if (Object.values(UiEvents).includes(event.data.type)) {
                 cb(event);
             }
-        });
+        }
+
+        window.addEventListener("message", _internalOnEvent);
+
+        return () => {
+            window.removeEventListener("message", _internalOnEvent);
+        }
     }
 
     return {

--- a/packages/ui/react-ui/src/CrossmintPaymentElement.tsx
+++ b/packages/ui/react-ui/src/CrossmintPaymentElement.tsx
@@ -1,20 +1,26 @@
-import React, { useEffect, useState } from "react";
+import React, {useEffect, useState} from "react";
 
-import { crossmintPaymentService, crossmintUiService } from "@crossmint/client-sdk-base";
-import type { CrossmintCheckoutEvent, PaymentElement } from "@crossmint/client-sdk-base";
+import type {CrossmintCheckoutEvent, PaymentElement} from "@crossmint/client-sdk-base";
+import {crossmintPaymentService, crossmintUiService} from "@crossmint/client-sdk-base";
 
 export function CrossmintPaymentElement(props: PaymentElement) {
     const [height, setHeight] = useState(0);
-    const { getIframeUrl, listenToEvents, emitQueryParams } = crossmintPaymentService(props);
-    const { listenToEvents: listenToUiEvents } = crossmintUiService({ environment: props.environment });
+    const {getIframeUrl, listenToEvents, emitQueryParams} = crossmintPaymentService(props);
+    const {listenToEvents: listenToUiEvents} = crossmintUiService({environment: props.environment});
 
     useEffect(() => {
-        listenToEvents((event: MessageEvent<CrossmintCheckoutEvent>) => props.onEvent?.(event.data));
+        const clearListener = listenToEvents((event: MessageEvent<CrossmintCheckoutEvent>) => props.onEvent?.(event.data));
+
+        return () => {
+            if (clearListener) {
+                clearListener();
+            }
+        }
     }, [listenToEvents, props.onEvent]);
 
     useEffect(() => {
-        listenToUiEvents((event: MessageEvent<any>) => {
-            const { type, payload } = event.data;
+        const clearListener = listenToUiEvents((event: MessageEvent<any>) => {
+            const {type, payload} = event.data;
 
             switch (type) {
                 case "ui:height.changed":
@@ -24,6 +30,12 @@ export function CrossmintPaymentElement(props: PaymentElement) {
                     return;
             }
         });
+
+        return () => {
+            if (clearListener) {
+                clearListener();
+            }
+        }
     }, []);
 
     useEffect(() => {

--- a/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
+++ b/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {onBeforeUnmount, ref, watch} from "vue";
+import { ref, watch } from "vue";
 
 import type {
     CrossmintCheckoutEvent,
@@ -10,7 +10,7 @@ import type {
     Recipient,
     UIConfig,
 } from "@crossmint/client-sdk-base";
-import {crossmintPaymentService, crossmintUiService} from "@crossmint/client-sdk-base";
+import { crossmintPaymentService, crossmintUiService } from "@crossmint/client-sdk-base";
 
 // TODO: Looks like you cannot import the interface directly from the package
 // https://github.com/vuejs/core/issues/4294#issuecomment-970861525
@@ -23,23 +23,22 @@ export interface PaymentElement {
     locale?: Locale;
     uiConfig?: UIConfig;
     environment?: string;
-
     onEvent?(event: CrossmintCheckoutEvent): any;
 }
 
 const props = withDefaults(defineProps<PaymentElement>(), {});
 
-const {getIframeUrl, listenToEvents, emitQueryParams} = crossmintPaymentService(props);
-const {listenToEvents: listenToUiEvents} = crossmintUiService({environment: props.environment});
+const { getIframeUrl, listenToEvents, emitQueryParams } = crossmintPaymentService(props);
+const { listenToEvents: listenToUiEvents } = crossmintUiService({ environment: props.environment });
 
 const iframeUrl = getIframeUrl();
 
 const styleHeight = ref(0);
 
-const clearEventListener = listenToEvents((event) => props.onEvent?.(event.data));
+listenToEvents((event) => props.onEvent?.(event.data));
 
-const clearUiListener = listenToUiEvents((event: MessageEvent<any>) => {
-    const {type, payload} = event.data;
+listenToUiEvents((event: MessageEvent<any>) => {
+    const { type, payload } = event.data;
 
     switch (type) {
         case "ui:height.changed":
@@ -53,21 +52,10 @@ const clearUiListener = listenToUiEvents((event: MessageEvent<any>) => {
 watch(
     () => [props.recipient, props.mintConfig, props.locale],
     () => {
-        emitQueryParams({recipient: props.recipient, mintConfig: props.mintConfig, locale: props.locale});
+        emitQueryParams({ recipient: props.recipient, mintConfig: props.mintConfig, locale: props.locale });
     },
-    {deep: true}
+    { deep: true }
 );
-
-onBeforeUnmount(() => {
-    if (clearEventListener) {
-        clearEventListener();
-    }
-
-    if (clearUiListener) {
-        clearUiListener();
-    }
-})
-
 </script>
 
 <template>

--- a/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
+++ b/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import {onBeforeUnmount, ref, watch} from "vue";
 
 import type {
     CrossmintCheckoutEvent,
@@ -10,7 +10,7 @@ import type {
     Recipient,
     UIConfig,
 } from "@crossmint/client-sdk-base";
-import { crossmintPaymentService, crossmintUiService } from "@crossmint/client-sdk-base";
+import {crossmintPaymentService, crossmintUiService} from "@crossmint/client-sdk-base";
 
 // TODO: Looks like you cannot import the interface directly from the package
 // https://github.com/vuejs/core/issues/4294#issuecomment-970861525
@@ -23,22 +23,23 @@ export interface PaymentElement {
     locale?: Locale;
     uiConfig?: UIConfig;
     environment?: string;
+
     onEvent?(event: CrossmintCheckoutEvent): any;
 }
 
 const props = withDefaults(defineProps<PaymentElement>(), {});
 
-const { getIframeUrl, listenToEvents, emitQueryParams } = crossmintPaymentService(props);
-const { listenToEvents: listenToUiEvents } = crossmintUiService({ environment: props.environment });
+const {getIframeUrl, listenToEvents, emitQueryParams} = crossmintPaymentService(props);
+const {listenToEvents: listenToUiEvents} = crossmintUiService({environment: props.environment});
 
 const iframeUrl = getIframeUrl();
 
 const styleHeight = ref(0);
 
-listenToEvents((event) => props.onEvent?.(event.data));
+const clearEventListener = listenToEvents((event) => props.onEvent?.(event.data));
 
-listenToUiEvents((event: MessageEvent<any>) => {
-    const { type, payload } = event.data;
+const clearUiListener = listenToUiEvents((event: MessageEvent<any>) => {
+    const {type, payload} = event.data;
 
     switch (type) {
         case "ui:height.changed":
@@ -52,10 +53,21 @@ listenToUiEvents((event: MessageEvent<any>) => {
 watch(
     () => [props.recipient, props.mintConfig, props.locale],
     () => {
-        emitQueryParams({ recipient: props.recipient, mintConfig: props.mintConfig, locale: props.locale });
+        emitQueryParams({recipient: props.recipient, mintConfig: props.mintConfig, locale: props.locale});
     },
-    { deep: true }
+    {deep: true}
 );
+
+onBeforeUnmount(() => {
+    if (clearEventListener) {
+        clearEventListener();
+    }
+
+    if (clearUiListener) {
+        clearUiListener();
+    }
+})
+
 </script>
 
 <template>


### PR DESCRIPTION
re-rendering payment element ,  react registers multiple message event listener and fires duplicate message event.  and causes high resource consumption.