### PR TITLE
Add listener remove functions

### DIFF
--- a/packages/core/base/src/models/paymentElement.ts
+++ b/packages/core/base/src/models/paymentElement.ts
@@ -126,3 +126,5 @@ export type ParamsUpdatePayload = Partial<Record<keyof Omit<PaymentElement, "onE
 export interface SDKEventMap {
     [PaymentElementSDKEvents.PARAMS_UPDATE]: ParamsUpdatePayload;
 }
+
+export type EventCallbackFunction = <K extends keyof CheckoutEventMap>(event: MessageEvent<CrossmintCheckoutEvent<K>>) => void;

--- a/packages/core/base/src/services/crossmintUiService.ts
+++ b/packages/core/base/src/services/crossmintUiService.ts
@@ -3,9 +3,10 @@ import { getEnvironmentBaseUrl } from "../utils";
 
 export function crossmintUiService({ environment }: { environment?: string } = {}) {
     const baseUrl = getEnvironmentBaseUrl(environment);
+    let listeners: Array<(event: MessageEvent) => void> = [];
 
     function listenToEvents(cb: (event: MessageEvent) => void) {
-        window.addEventListener("message", (event) => {
+        const eventListener = (event: MessageEvent) => {
             if (event.origin !== baseUrl) {
                 return;
             }
@@ -13,10 +14,20 @@ export function crossmintUiService({ environment }: { environment?: string } = {
             if (Object.values(UiEvents).includes(event.data.type)) {
                 cb(event);
             }
+        }
+        window.addEventListener("message", eventListener);
+        listeners.push(eventListener);
+    }
+
+    function removeEventListeners() {
+        listeners.forEach((listener) => {
+            window.removeEventListener("message", listener);
         });
+        listeners = [];
     }
 
     return {
         listenToEvents,
+        removeEventListeners,
     };
 }


### PR DESCRIPTION
Added a removeEventListeners function to crossmintPaymentService and crossmintUIService. 

I had noticed an issue where events were firing off multiple times if the embedded payment component was removed and recreated. I added this in so I could remove the listeners on the component destroy callback.

Edit: I just realized #219 covers this same bug in a different way. 