### PR TITLE
Remove event listeners when unmounting the Lit and Vue component.

### DIFF
--- a/packages/ui/vanilla-ui/src/CrossmintPaymentElement.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPaymentElement.ts
@@ -58,6 +58,9 @@ export class CrossmintPaymentElement extends LitElement {
   onEvent?: (event: any) => void = propertyDefaults.onEvent;
 
   height: number = 0;
+  removeEventListener = () => {};
+  removeUIEventListener = () => {};
+
 
   connectedCallback() {
     super.connectedCallback();
@@ -67,9 +70,9 @@ export class CrossmintPaymentElement extends LitElement {
     const { listenToEvents } = crossmintPaymentService({ clientId: this.clientId, environment: this.environment, uiConfig: this.uiConfig, recipient: this.recipient, mintConfig: this.mintConfig });
     const { listenToEvents: listenToUiEvents } = crossmintUiService({ environment: this.environment });
 
-    listenToEvents((event) => onEvent?.(event.data));
+    this.removeEventListener = listenToEvents((event) => onEvent?.(event.data));
 
-    listenToUiEvents((event: MessageEvent<any>) => {
+    this.removeUIEventListener = listenToUiEvents((event: MessageEvent<any>) => {
       const { type, payload } = event.data;
 
       switch (type) {
@@ -80,8 +83,14 @@ export class CrossmintPaymentElement extends LitElement {
           default:
               return;
       }
-  });
+    });
+  }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    this.removeEventListener();
+    this.removeUIEventListener();
   }
 
   updated(changedProperties: Map<string, unknown>) {

--- a/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
+++ b/packages/ui/vue-ui/src/components/CrossmintPaymentElement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, onUnmounted } from "vue";
 
 import type {
     CrossmintCheckoutEvent,
@@ -35,9 +35,9 @@ const iframeUrl = getIframeUrl();
 
 const styleHeight = ref(0);
 
-listenToEvents((event) => props.onEvent?.(event.data));
+const removeEventListener = listenToEvents((event) => props.onEvent?.(event.data));
 
-listenToUiEvents((event: MessageEvent<any>) => {
+const removeUIEventListener = listenToUiEvents((event: MessageEvent<any>) => {
     const { type, payload } = event.data;
 
     switch (type) {
@@ -47,6 +47,11 @@ listenToUiEvents((event: MessageEvent<any>) => {
         default:
             return;
     }
+});
+
+onUnmounted(() => {
+    removeEventListener();
+    removeUIEventListener();
 });
 
 watch(


### PR DESCRIPTION
Updated Vue and Lit component to remove event listeners on unmount. This is essentially doing the same thing #219 did for the React component. Covers bug #224.