### PR TITLE
Remove and deprecate CrossmintStatusButton from client-sdk

### DIFF
--- a/packages/ui/react-ui/src/types.ts
+++ b/packages/ui/react-ui/src/types.ts
@@ -1,13 +1,8 @@
 import { CSSProperties, MouseEvent } from "react";
 
-import { BaseButtonProps, CrossmintPayButtonProps } from "@crossmint/client-sdk-base";
+import { CrossmintPayButtonProps } from "@crossmint/client-sdk-base";
 
 export type CrossmintPayButtonReactProps = CrossmintPayButtonProps & {
-    onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
-    style?: CSSProperties;
-};
-
-export type CrossmintStatusButtonReactProps = BaseButtonProps & {
     onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
     style?: CSSProperties;
 };

--- a/packages/ui/vanilla-ui/src/types.ts
+++ b/packages/ui/vanilla-ui/src/types.ts
@@ -1,9 +1,6 @@
-import { BaseButtonProps, CrossmintPayButtonProps } from "@crossmint/client-sdk-base";
+import { CrossmintPayButtonProps } from "@crossmint/client-sdk-base";
 
 export type CrossmintPayButtonLitProps = CrossmintPayButtonProps & {
     onClick?: (e: any) => void;
 };
 
-export type CrossmintStatusButtonLitProps = BaseButtonProps & {
-    onClick?: (e: any) => void;
-};


### PR DESCRIPTION
The endpoints for the CrossmintStatusButton have been removed from crossmint-main, we should officially deprecate and remove all the related code in our client sdk