### PR TITLE
pay button: custom text prop

### DIFF
--- a/packages/core/base/src/models/types.ts
+++ b/packages/core/base/src/models/types.ts
@@ -94,6 +94,7 @@ export type CrossmintPayButtonProps = BaseButtonProps & {
     successCallbackURL?: string;
     failureCallbackURL?: string;
     loginEmail?: string;
+    getButtonText?: (connecting: boolean, paymentMethod: PaymentMethod) => string;
     // TODO: Enable when events are ready in crossbit-main and docs are updated
     // onEvent?: (event: CheckoutEvents, metadata?: Record<string, any>) => void;
 };

--- a/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
+++ b/packages/ui/react-ui/__tests__/CrossmintPayButton.spec.tsx
@@ -181,4 +181,11 @@ describe("CrossmintPayButton", () => {
             );
         });
     });
+
+    describe("when passing getButtonText prop", () => {
+        test("should show custom text", async () => {
+            render(<CrossmintPayButton {...defaultProps} getButtonText={() => "Custom text"} />);
+            expect(screen.getByText("Custom text")).toBeInTheDocument();
+        });
+    });
 });

--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -43,6 +43,7 @@ export function CrossmintPayButton(buttonProps: CrossmintPayButtonReactProps) {
         failureCallbackURL = "",
         loginEmail = "",
         projectId,
+        getButtonText,
         ...props
     } = buttonProps;
 
@@ -67,7 +68,7 @@ export function CrossmintPayButton(buttonProps: CrossmintPayButtonReactProps) {
         loginEmail,
     });
 
-    const { getButtonText, handleClick } = crossmintPayButtonService({
+    const { getButtonText: getButtonTextInternal, handleClick } = crossmintPayButtonService({
         onClick,
         connecting,
         paymentMethod,
@@ -93,7 +94,9 @@ export function CrossmintPayButton(buttonProps: CrossmintPayButtonReactProps) {
     const content = useMemo(() => {
         return (
             <span className={classes.crossmintParagraph} role="button-paragraph">
-                {getButtonText(connecting)}
+                {getButtonText != null
+                    ? getButtonText(connecting, paymentMethod || "fiat")
+                    : getButtonTextInternal(connecting)}
             </span>
         );
     }, [connecting]);

--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -39,7 +39,8 @@ const propertyDefaults: CrossmintPayButtonLitProps = {
     currency: "usd",
     successCallbackURL: "",
     failureCallbackURL: "",
-    loginEmail: ""
+    loginEmail: "",
+    getButtonText: undefined,
 };
 
 @customElement("crossmint-pay-button")
@@ -111,9 +112,12 @@ export class CrossmintPayButton extends LitElement {
 
     @property({ type: String })
     failureCallbackURL = propertyDefaults.failureCallbackURL;
-    
+
     @property({ type: String })
     loginEmail = propertyDefaults.loginEmail;
+
+    @property({ type: Function })
+    getButtonText = propertyDefaults.getButtonText;
 
     static styles = buttonStyles;
 
@@ -129,14 +133,14 @@ export class CrossmintPayButton extends LitElement {
     }
 
     render() {
-        const { handleClick, getButtonText } = crossmintPayButtonService({
+        const { handleClick, getButtonText: getButtonTextInteral } = crossmintPayButtonService({
             onClick: this.onClick,
             connecting: this.connecting,
             paymentMethod: this.paymentMethod,
             locale: this.locale || "en-US",
         });
 
-        const content = getButtonText(this.connecting);
+        const content = this.getButtonText != null ? this.getButtonText(this.connecting, this.paymentMethod || "fiat") : getButtonTextInteral(this.connecting);
 
         const { connect } = crossmintModalService({
             environment: this.environment,


### PR DESCRIPTION
- new prop `getButtonText(connecting:boolean, paymentMethod:PaymentMethod)` allowing devs to custom control the text from js

## Test plan

Tested locally, added new unit test