### PR TITLE
Set the default mintConfig to an empty object

### DIFF
--- a/packages/ui/react-ui/src/CrossmintPayButton.tsx
+++ b/packages/ui/react-ui/src/CrossmintPayButton.tsx
@@ -21,7 +21,7 @@ export function CrossmintPayButton(buttonProps: CrossmintPayButtonReactProps) {
         listingId,
         auctionId,
         showOverlay = true,
-        mintConfig,
+        mintConfig = {},
         whPassThroughArgs,
         environment,
         paymentMethod,

--- a/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
+++ b/packages/ui/vanilla-ui/src/CrossmintPayButton.ts
@@ -36,6 +36,7 @@ const propertyDefaults: CrossmintPayButtonLitProps = {
     failureCallbackURL: "",
     loginEmail: "",
     getButtonText: undefined,
+    mintConfig: {}
 };
 
 @customElement("crossmint-pay-button")


### PR DESCRIPTION
Set the default mintConfig to be an empty object in case the mintConfig property was never passed.

Was able to test the vanillajs change locally, unsure how to test the react change